### PR TITLE
Add support for resumable uploads for File API

### DIFF
--- a/google/generativeai/client.py
+++ b/google/generativeai/client.py
@@ -76,7 +76,8 @@ class FileServiceClient(glm.FileServiceClient):
             if chunksize is None:
                 chunksize = googleapiclient.http.DEFAULT_CHUNK_SIZE
             media = googleapiclient.http.MediaFileUpload(
-                filename=path, mimetype=mime_type, resumable=resumable, chunksize=chunksize)
+                filename=path, mimetype=mime_type, resumable=resumable, chunksize=chunksize
+            )
         else:
             media = googleapiclient.http.MediaFileUpload(filename=path, mimetype=mime_type)
         request = self._discovery_api.media().upload(body={"file": file}, media_body=media)

--- a/google/generativeai/client.py
+++ b/google/generativeai/client.py
@@ -59,6 +59,8 @@ class FileServiceClient(glm.FileServiceClient):
         mime_type: str | None = None,
         name: str | None = None,
         display_name: str | None = None,
+        resumable: bool | None = None,
+        chunksize: float | None = None,
     ) -> glm.File:
         if self._discovery_api is None:
             self._setup_discovery_api()
@@ -69,7 +71,14 @@ class FileServiceClient(glm.FileServiceClient):
         if display_name is not None:
             file["displayName"] = display_name
 
-        media = googleapiclient.http.MediaFileUpload(filename=path, mimetype=mime_type)
+        # Rely on MediaFileUpload for resumable uploads.
+        if resumable is not None:
+            if chunksize is None:
+                chunksize = googleapiclient.http.DEFAULT_CHUNK_SIZE
+            media = googleapiclient.http.MediaFileUpload(
+                filename=path, mimetype=mime_type, resumable=resumable, chunksize=chunksize)
+        else:
+            media = googleapiclient.http.MediaFileUpload(filename=path, mimetype=mime_type)
         request = self._discovery_api.media().upload(body={"file": file}, media_body=media)
         result = request.execute()
 

--- a/google/generativeai/client.py
+++ b/google/generativeai/client.py
@@ -59,8 +59,7 @@ class FileServiceClient(glm.FileServiceClient):
         mime_type: str | None = None,
         name: str | None = None,
         display_name: str | None = None,
-        resumable: bool | None = None,
-        chunksize: int | None = None,
+        resumable: bool = True,
     ) -> glm.File:
         if self._discovery_api is None:
             self._setup_discovery_api()
@@ -71,15 +70,9 @@ class FileServiceClient(glm.FileServiceClient):
         if display_name is not None:
             file["displayName"] = display_name
 
-        # Rely on MediaFileUpload for resumable uploads.
-        if resumable is not None:
-            if chunksize is None:
-                chunksize = googleapiclient.http.DEFAULT_CHUNK_SIZE
-            media = googleapiclient.http.MediaFileUpload(
-                filename=path, mimetype=mime_type, resumable=resumable, chunksize=chunksize
-            )
-        else:
-            media = googleapiclient.http.MediaFileUpload(filename=path, mimetype=mime_type)
+        media = googleapiclient.http.MediaFileUpload(
+            filename=path, mimetype=mime_type, resumable=resumable
+        )
         request = self._discovery_api.media().upload(body={"file": file}, media_body=media)
         result = request.execute()
 

--- a/google/generativeai/client.py
+++ b/google/generativeai/client.py
@@ -60,7 +60,7 @@ class FileServiceClient(glm.FileServiceClient):
         name: str | None = None,
         display_name: str | None = None,
         resumable: bool | None = None,
-        chunksize: float | None = None,
+        chunksize: int | None = None,
     ) -> glm.File:
         if self._discovery_api is None:
             self._setup_discovery_api()

--- a/google/generativeai/files.py
+++ b/google/generativeai/files.py
@@ -36,7 +36,7 @@ def upload_file(
     name: str | None = None,
     display_name: str | None = None,
     resumable: bool | None = None,
-    chunksize: float | None = None,
+    chunksize: int | None = None,
 ) -> file_types.File:
     """Uploads a file using a supported file service.
 
@@ -50,7 +50,7 @@ def upload_file(
         resumable: Whether to use the resumable upload protocol. By default, this is disabled.
             See details at
             https://googleapis.github.io/google-api-python-client/docs/epy/googleapiclient.http.MediaFileUpload-class.html#resumable
-        chunksize: The size of file chunks for resumable uploads, in bytes.
+        chunksize: The size of file chunk bytes for resumable uploads, in int.
             If not provided, a default value is used. For more information,
             see https://googleapis.github.io/google-api-python-client/docs/epy/googleapiclient.http.MediaFileUpload-class.html#chunksize
 

--- a/google/generativeai/files.py
+++ b/google/generativeai/files.py
@@ -35,8 +35,7 @@ def upload_file(
     mime_type: str | None = None,
     name: str | None = None,
     display_name: str | None = None,
-    resumable: bool | None = None,
-    chunksize: int | None = None,
+    resumable: bool = True,
 ) -> file_types.File:
     """Uploads a file using a supported file service.
 
@@ -47,12 +46,9 @@ def upload_file(
         name: The name of the file in the destination (e.g., 'files/sample-image').
             If not provided, a system generated ID will be created.
         display_name: Optional display name of the file.
-        resumable: Whether to use the resumable upload protocol. By default, this is disabled.
+        resumable: Whether to use the resumable upload protocol. By default, this is enabled.
             See details at
             https://googleapis.github.io/google-api-python-client/docs/epy/googleapiclient.http.MediaFileUpload-class.html#resumable
-        chunksize: The size of file chunk bytes for resumable uploads, in int.
-            If not provided, a default value is used. For more information,
-            see https://googleapis.github.io/google-api-python-client/docs/epy/googleapiclient.http.MediaFileUpload-class.html#chunksize
 
     Returns:
         file_types.File: The response of the uploaded file.
@@ -71,12 +67,7 @@ def upload_file(
         display_name = path.name
 
     response = client.create_file(
-        path=path,
-        mime_type=mime_type,
-        name=name,
-        display_name=display_name,
-        resumable=resumable,
-        chunksize=chunksize,
+        path=path, mime_type=mime_type, name=name, display_name=display_name, resumable=resumable
     )
     return file_types.File(response)
 

--- a/google/generativeai/files.py
+++ b/google/generativeai/files.py
@@ -35,7 +35,28 @@ def upload_file(
     mime_type: str | None = None,
     name: str | None = None,
     display_name: str | None = None,
+    resumable: bool | None = None,
+    chunksize: float | None = None,
 ) -> file_types.File:
+    """Uploads a file using a supported file service.
+
+    Args:
+        path: The path to the file to be uploaded.
+        mime_type: The MIME type of the file. If not provided, it will be
+            inferred from the file extension.
+        name: The name of the file in the destination (e.g., 'files/sample-image').
+            If not provided, a system generated ID will be created.
+        display_name: Optional display name of the file.
+        resumable: Whether to use the resumable upload protocol. By default, this is disabled.
+            See details at
+            https://googleapis.github.io/google-api-python-client/docs/epy/googleapiclient.http.MediaFileUpload-class.html#resumable
+        chunksize: The size of file chunks for resumable uploads, in bytes.
+            If not provided, a default value is used. For more information,
+            see https://googleapis.github.io/google-api-python-client/docs/epy/googleapiclient.http.MediaFileUpload-class.html#chunksize
+
+    Returns:
+        file_types.File: The response of the uploaded file.
+   """
     client = get_default_file_client()
 
     path = pathlib.Path(os.fspath(path))
@@ -50,7 +71,8 @@ def upload_file(
         display_name = path.name
 
     response = client.create_file(
-        path=path, mime_type=mime_type, name=name, display_name=display_name
+        path=path, mime_type=mime_type, name=name, display_name=display_name,
+        resumable=resumable, chunksize=chunksize
     )
     return file_types.File(response)
 

--- a/google/generativeai/files.py
+++ b/google/generativeai/files.py
@@ -56,7 +56,7 @@ def upload_file(
 
     Returns:
         file_types.File: The response of the uploaded file.
-   """
+    """
     client = get_default_file_client()
 
     path = pathlib.Path(os.fspath(path))
@@ -71,8 +71,12 @@ def upload_file(
         display_name = path.name
 
     response = client.create_file(
-        path=path, mime_type=mime_type, name=name, display_name=display_name,
-        resumable=resumable, chunksize=chunksize
+        path=path,
+        mime_type=mime_type,
+        name=name,
+        display_name=display_name,
+        resumable=resumable,
+        chunksize=chunksize,
     )
     return file_types.File(response)
 


### PR DESCRIPTION
Add support for resumable uploads by following the MediaFileUpload class in Python:

https://googleapis.github.io/google-api-python-client/docs/epy/googleapiclient.http.MediaFileUpload-class.html

Add some pydocs to clarify what the parameters specified are. Confirmed this is working locally:

![image](https://github.com/google/generative-ai-python/assets/6380209/46e0ca5a-d5e9-4071-980e-b06d79e56c28)
