### PR TITLE
Restrict Harm category to the sublist only Gemini support

### DIFF
--- a/google/generativeai/text.py
+++ b/google/generativeai/text.py
@@ -81,7 +81,7 @@ def _make_generate_text_request(
     max_output_tokens: int | None = None,
     top_p: int | None = None,
     top_k: int | None = None,
-    safety_settings: safety_types.SafetySettingOptions | None = None,
+    safety_settings: safety_types.GeminiSafetySettingOptions | None = None,
     stop_sequences: str | Iterable[str] | None = None,
 ) -> glm.GenerateTextRequest:
     """
@@ -138,7 +138,7 @@ def generate_text(
     max_output_tokens: int | None = None,
     top_p: float | None = None,
     top_k: float | None = None,
-    safety_settings: safety_types.SafetySettingOptions | None = None,
+    safety_settings: safety_types.GeminiSafetySettingOptions | None = None,
     stop_sequences: str | Iterable[str] | None = None,
     client: glm.TextServiceClient | None = None,
     request_options: dict[str, Any] | None = None,

--- a/google/generativeai/types/safety_types.py
+++ b/google/generativeai/types/safety_types.py
@@ -14,6 +14,7 @@ from google.generativeai import string_utils
 
 __all__ = [
     "HarmCategory",
+    "GeminiHarmCategory",
     "HarmProbability",
     "HarmBlockThreshold",
     "BlockedReason",
@@ -30,6 +31,21 @@ HarmBlockThreshold = glm.SafetySetting.HarmBlockThreshold
 BlockedReason = glm.ContentFilter.BlockedReason
 
 HarmCategoryOptions = Union[str, int, HarmCategory]
+
+
+class GeminiHarmCategory:
+    """
+    The Harm Category that only supported by the gemini model
+    """
+
+    HARM_CATEGORY_UNSPECIFIED = glm.HarmCategory.HARM_CATEGORY_UNSPECIFIED
+    HARM_CATEGORY_HARASSMENT = glm.HarmCategory.HARM_CATEGORY_HARASSMENT
+    HARM_CATEGORY_HATE_SPEECH = glm.HarmCategory.HARM_CATEGORY_HATE_SPEECH
+    HARM_CATEGORY_SEXUALLY_EXPLICIT = glm.HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT
+    HARM_CATEGORY_DANGEROUS_CONTENT = glm.HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT
+
+
+GeminiHarmCategoryOptions = Union[str, int, GeminiHarmCategory]
 
 # fmt: off
 _OLD_HARM_CATEGORIES: Dict[HarmCategoryOptions, HarmCategory] = {
@@ -220,6 +236,9 @@ EasySafetySetting = Mapping[HarmCategoryOptions, HarmBlockThresholdOptions]
 EasySafetySettingDict = dict[HarmCategoryOptions, HarmBlockThresholdOptions]
 
 SafetySettingOptions = Union[EasySafetySetting, Iterable[LooseSafetySettingDict], None]
+
+GeminiEasySafetySetting = Mapping[GeminiHarmCategoryOptions, HarmBlockThresholdOptions]
+GeminiSafetySettingOptions = Union[GeminiEasySafetySetting, Iterable[LooseSafetySettingDict], None]
 
 
 def to_easy_safety_dict(settings: SafetySettingOptions, harm_category_set) -> EasySafetySettingDict:


### PR DESCRIPTION
## Description of the change
Restrict Harm category to the sublist only Gemini support



## Motivation
Create a subcategory of the list of harm category so that user will not confuse with the Palm ones. 

## Type of change
Choose one:  Feature request

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->
- [ ] I have performed a self-review of my code.
- [ ] I have added detailed comments to my code where applicable.
- [ ] I have verified that my change does not break existing code.
- [ ] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [ ] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [ ] I have read through the [Contributing Guide](https://github.com/google/generative-ai-python/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
