### PR TITLE
Revert "Use api_endpoint for uploads (#330)"

### DIFF
--- a/google/generativeai/client.py
+++ b/google/generativeai/client.py
@@ -27,6 +27,7 @@ except ImportError:
     __version__ = "0.0.0"
 
 USER_AGENT = "genai-py"
+GENAI_API_DISCOVERY_URL = "https://generativelanguage.googleapis.com/$discovery/rest"
 
 
 class FileServiceClient(glm.FileServiceClient):
@@ -42,7 +43,7 @@ class FileServiceClient(glm.FileServiceClient):
         request = googleapiclient.http.HttpRequest(
             http=httplib2.Http(),
             postproc=lambda resp, content: (resp, content),
-            uri=f"https://{self.api_endpoint}/$discovery/rest?version=v1beta&key={api_key}",
+            uri=f"{GENAI_API_DISCOVERY_URL}?version=v1beta&key={api_key}",
         )
         response, content = request.execute()
 


### PR DESCRIPTION
This is causing a conflict with colab: colab's api_endpoint redirectsthrough localhost, and the redirector doesn't allow the discovery service through.