### PR TITLE
Quick safety filtering: Allow `safety_settings="block_none"`

### DIFF
--- a/google/generativeai/types/safety_types.py
+++ b/google/generativeai/types/safety_types.py
@@ -219,15 +219,16 @@ class LooseSafetySettingDict(TypedDict):
 EasySafetySetting = Mapping[HarmCategoryOptions, HarmBlockThresholdOptions]
 EasySafetySettingDict = dict[HarmCategoryOptions, HarmBlockThresholdOptions]
 
-SafetySettingOptions = Union[HarmBlockThresholdOptions, EasySafetySetting, Iterable[LooseSafetySettingDict], None]
+SafetySettingOptions = Union[
+    HarmBlockThresholdOptions, EasySafetySetting, Iterable[LooseSafetySettingDict], None
+]
 
-def _expand_block_threshold(block_threshold:HarmBlockThresholdOptions):
+
+def _expand_block_threshold(block_threshold: HarmBlockThresholdOptions):
     block_threshold = to_block_threshold(block_threshold)
     set(_NEW_HARM_CATEGORIES.values())
-    return {
-        category: block_threshold
-        for category in set(_NEW_HARM_CATEGORIES.values())
-    }
+    return {category: block_threshold for category in set(_NEW_HARM_CATEGORIES.values())}
+
 
 def to_easy_safety_dict(settings: SafetySettingOptions, harm_category_set) -> EasySafetySettingDict:
     if settings is None:

--- a/google/generativeai/types/safety_types.py
+++ b/google/generativeai/types/safety_types.py
@@ -228,9 +228,13 @@ def to_easy_safety_dict(settings: SafetySettingOptions) -> EasySafetySettingDict
             if isinstance(setting, glm.SafetySetting):
                 result[to_harm_category(setting.category)] = to_block_threshold(setting.threshold)
             elif isinstance(setting, dict):
-                result[to_harm_category(setting["category"])] = to_block_threshold(setting["threshold"])
+                result[to_harm_category(setting["category"])] = to_block_threshold(
+                    setting["threshold"]
+                )
             else:
-                raise ValueError(f"Could not understand safety setting:\n  {type(setting)=}\n  {setting=}")
+                raise ValueError(
+                    f"Could not understand safety setting:\n  {type(setting)=}\n  {setting=}"
+                )
         return result
 
 

--- a/tests/test_generative_models.py
+++ b/tests/test_generative_models.py
@@ -155,6 +155,7 @@ class CUJTests(parameterized.TestCase):
 
     @parameterized.named_parameters(
         ["dict", {"danger": "low"}, {"danger": "high"}],
+        ["quick", "low", "high"],
         [
             "list-dict",
             [
@@ -193,22 +194,25 @@ class CUJTests(parameterized.TestCase):
         ]
 
         _ = model.generate_content("hello")
+
+        danger = [
+            s
+            for s in self.observed_requests[-1].safety_settings
+            if s.category == glm.HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT
+        ]
         self.assertEqual(
-            self.observed_requests[-1].safety_settings[0].category,
-            glm.HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
-        )
-        self.assertEqual(
-            self.observed_requests[-1].safety_settings[0].threshold,
+            danger[0].threshold,
             glm.SafetySetting.HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,
         )
 
         _ = model.generate_content("hello", safety_settings=safe2)
+        danger = [
+            s
+            for s in self.observed_requests[-1].safety_settings
+            if s.category == glm.HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT
+        ]
         self.assertEqual(
-            self.observed_requests[-1].safety_settings[0].category,
-            glm.HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
-        )
-        self.assertEqual(
-            self.observed_requests[-1].safety_settings[0].threshold,
+            danger[0].threshold,
             glm.SafetySetting.HarmBlockThreshold.BLOCK_ONLY_HIGH,
         )
 

--- a/tests/test_generative_models.py
+++ b/tests/test_generative_models.py
@@ -181,7 +181,7 @@ class CUJTests(parameterized.TestCase):
     )
     def test_safety_overwrite(self, safe1, safe2):
         # Safety
-        model = generative_models.GenerativeModel("gemini-pro", safety_settings={"danger": "low"})
+        model = generative_models.GenerativeModel("gemini-pro", safety_settings=safe1)
 
         self.responses["generate_content"] = [
             simple_response(" world!"),
@@ -198,7 +198,7 @@ class CUJTests(parameterized.TestCase):
             glm.SafetySetting.HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,
         )
 
-        _ = model.generate_content("hello", safety_settings={"danger": "high"})
+        _ = model.generate_content("hello", safety_settings=safe2)
         self.assertEqual(
             self.observed_requests[-1].safety_settings[0].category,
             glm.HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -1,0 +1,82 @@
+import collections
+from collections.abc import Iterable
+import copy
+import pathlib
+from typing import Any
+import textwrap
+import unittest.mock
+from absl.testing import absltest
+from absl.testing import parameterized
+import google.ai.generativelanguage as glm
+from google.generativeai import client as client_lib
+from google.generativeai import generative_models
+from google.generativeai.types import content_types
+from google.generativeai.types import generation_types
+
+import PIL.Image
+
+
+class SafetyTests(parameterized.TestCase):
+    """Tests are in order with the design doc."""
+
+    @parameterized.named_parameters(
+        ["block_threshold", glm.SafetySetting.HarmBlockThreshold.BLOCK_LOW_AND_ABOVE],
+        ["block_threshold", "low"],
+        ["block_threshold", 1],
+        ["dict", {"danger": "low"}, {"danger": "high"}],
+        [
+            "list-dict",
+            [
+                dict(
+                    category=glm.HarmCategory.HARM_CATEGORY_DANGEROUS,
+                    threshold=glm.SafetySetting.HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,
+                ),
+            ],
+            ],[
+            "list-dict2"
+            [
+                dict(category="danger", threshold="high"),
+            ],
+        ],
+        [
+            "object",
+            [
+                glm.SafetySetting(
+                    category=glm.HarmCategory.HARM_CATEGORY_DANGEROUS,
+                    threshold=glm.SafetySetting.HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,
+                ),
+            ],
+        ],
+    )
+    def test_safety_overwrite(self, safe1, safe2):
+        # Safety
+        model = generative_models.GenerativeModel("gemini-pro", safety_settings=safe1)
+
+        self.responses["generate_content"] = [
+            simple_response(" world!"),
+            simple_response(" world!"),
+        ]
+
+        _ = model.generate_content("hello")
+        self.assertEqual(
+            self.observed_requests[-1].safety_settings[0].category,
+            glm.HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
+        )
+        self.assertEqual(
+            self.observed_requests[-1].safety_settings[0].threshold,
+            glm.SafetySetting.HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,
+        )
+
+        _ = model.generate_content("hello", safety_settings=safe2)
+        self.assertEqual(
+            self.observed_requests[-1].safety_settings[0].category,
+            glm.HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
+        )
+        self.assertEqual(
+            self.observed_requests[-1].safety_settings[0].threshold,
+            glm.SafetySetting.HarmBlockThreshold.BLOCK_ONLY_HIGH,
+        )
+
+
+if __name__ == "__main__":
+    absltest.main()

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -1,19 +1,22 @@
-import collections
-from collections.abc import Iterable
-import copy
-import pathlib
-from typing import Any
-import textwrap
-import unittest.mock
+# -*- coding: utf-8 -*-
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from absl.testing import absltest
 from absl.testing import parameterized
 import google.ai.generativelanguage as glm
-from google.generativeai import client as client_lib
-from google.generativeai import generative_models
 from google.generativeai.types import safety_types
-from google.generativeai.types import generation_types
-
-import PIL.Image
 
 
 class SafetyTests(parameterized.TestCase):


### PR DESCRIPTION
generate_content(safety_setting='BLOCK_NONE')