### PR TITLE
Explicit Caching

### DIFF
--- a/google/generativeai/caching.py
+++ b/google/generativeai/caching.py
@@ -80,7 +80,7 @@ class CachedContent:
     @staticmethod
     def _prepare_create_request(
         model: str,
-        name: str = None,
+        name: str | None = None,
         system_instruction: Optional[content_types.ContentType] = None,
         contents: Optional[content_types.ContentsType] = None,
         tools: Optional[content_types.FunctionLibraryType] = None,
@@ -129,7 +129,7 @@ class CachedContent:
     def create(
         cls,
         model: str,
-        name: str = None,
+        name: str | None = None,
         system_instruction: Optional[content_types.ContentType] = None,
         contents: Optional[content_types.ContentsType] = None,
         tools: Optional[content_types.FunctionLibraryType] = None,

--- a/google/generativeai/caching.py
+++ b/google/generativeai/caching.py
@@ -91,7 +91,7 @@ class CachedContent:
         if name is not None:
             if not caching_types.valid_cached_content_name(name):
                 raise ValueError(caching_types.NAME_ERROR_MESSAGE.format(name=name))
-            
+
             name = "cachedContents/" + name
 
         if "/" not in model:

--- a/google/generativeai/caching.py
+++ b/google/generativeai/caching.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+from typing import Optional, Iterable
+
+import google.ai.generativelanguage as glm
+
+from google.generativeai.types import caching_types
+from google.generativeai.types import content_types
+from google.generativeai.client import get_default_cache_client
+
+
+# alias for `caching_types.CachedContent`.
+CachedContent = caching_types.CachedContent
+
+
+def get_cached_content(name: str, client: glm.CacheServiceClient | None = None) -> CachedContent:
+    """Fetches required `CachedContent` resource.
+
+    Args:
+        name: name: The resource name referring to the cached content.
+
+    Returns:
+        `CachedContent` resource with specified name.
+    """
+    return CachedContent.get_cached_content(name=name, client=client)
+
+
+def delete_cached_content(name: str, client: glm.CacheServiceClient | None = None) -> None:
+    """Deletes `CachedContent` resource.
+
+    Args:
+        name: The resource name referring to the cached content.
+              Format: cachedContents/{id}.
+    """
+    if client is None:
+        client = get_default_cache_client()
+
+    if "cachedContents/" not in name:
+        name = "cachedContents/" + name
+
+    request = glm.DeleteCachedContentRequest(name=name)
+    client.delete_cached_content(request)
+    return
+
+
+def list_cached_contents(
+    page_size: Optional[int] = 1, client: glm.CacheServiceClient | None = None
+) -> Iterable[CachedContent]:
+    """Lists `CachedContent` objects associated with the project.
+
+    Args:
+        page_size: The maximum number of permissions to return (per page). The service may return fewer `CachedContent` objects.
+
+    Returns:
+        A paginated list of `CachedContent` objects.
+    """
+    if client is None:
+        client = get_default_cache_client()
+
+    request = glm.ListCachedContentsRequest(page_size=page_size)
+    for cached_content in client.list_cached_contents(request):
+        yield caching_types.decode_cached_content(cached_content)

--- a/google/generativeai/caching.py
+++ b/google/generativeai/caching.py
@@ -210,12 +210,7 @@ class CachedContent:
             yield cls._decode_cached_content(cached_content)
 
     def delete(self, client: glm.CachedServiceClient | None = None) -> None:
-        """Deletes `CachedContent` resource.
-
-        Args:
-            name: The resource name referring to the cached content.
-                Format: cachedContents/{id}.
-        """
+        """Deletes `CachedContent` resource."""
         if client is None:
             client = get_default_cache_client()
 

--- a/google/generativeai/caching.py
+++ b/google/generativeai/caching.py
@@ -79,8 +79,8 @@ class CachedContent:
 
     @staticmethod
     def _prepare_create_request(
-        name: str,
         model: str,
+        name: str = None,
         system_instruction: Optional[content_types.ContentType] = None,
         contents: Optional[content_types.ContentsType] = None,
         tools: Optional[content_types.FunctionLibraryType] = None,
@@ -88,10 +88,11 @@ class CachedContent:
         ttl: Optional[caching_types.ExpirationTypes] = datetime.timedelta(hours=1),
     ) -> glm.CreateCachedContentRequest:
         """Prepares a CreateCachedContentRequest."""
-        if caching_types.valid_cached_content_name(name):
+        if name is not None:
+            if not caching_types.valid_cached_content_name(name):
+                raise ValueError(caching_types.NAME_ERROR_MESSAGE.format(name=name))
+            
             name = "cachedContents/" + name
-        else:
-            raise ValueError(caching_types.NAME_ERROR_MESSAGE.format(name=name))
 
         if "/" not in model:
             model = "models/" + model
@@ -127,8 +128,8 @@ class CachedContent:
     @classmethod
     def create(
         cls,
-        name: str,
         model: str,
+        name: str = None,
         system_instruction: Optional[content_types.ContentType] = None,
         contents: Optional[content_types.ContentsType] = None,
         tools: Optional[content_types.FunctionLibraryType] = None,
@@ -139,11 +140,10 @@ class CachedContent:
         """Creates CachedContent resource.
 
         Args:
-            name: The resource name referring to the cached content.
-                  Format: cachedContents/{id}.
             model: The name of the `Model` to use for cached content
                     Format: models/{model}. Cached content resource can be only
                     used with model it was created for.
+            name: The resource name referring to the cached content.
             system_instruction: Developer set system instruction.
             contents: Contents to cache.
             tools: A list of `Tools` the model may use to generate response.
@@ -157,8 +157,8 @@ class CachedContent:
             client = get_default_cache_client()
 
         request = cls._prepare_create_request(
-            name=name,
             model=model,
+            name=name,
             system_instruction=system_instruction,
             contents=contents,
             tools=tools,

--- a/google/generativeai/caching.py
+++ b/google/generativeai/caching.py
@@ -36,7 +36,7 @@ def get_cached_content(name: str, client: glm.CacheServiceClient | None = None) 
     Returns:
         `CachedContent` resource with specified name.
     """
-    return CachedContent.get_cached_content(name=name, client=client)
+    return CachedContent.get(name=name, client=client)
 
 
 def delete_cached_content(name: str, client: glm.CacheServiceClient | None = None) -> None:

--- a/google/generativeai/caching.py
+++ b/google/generativeai/caching.py
@@ -88,8 +88,10 @@ class CachedContent:
         ttl: Optional[caching_types.ExpirationTypes] = datetime.timedelta(hours=1),
     ) -> glm.CreateCachedContentRequest:
         """Prepares a CreateCachedContentRequest."""
-        if "cachedContents/" not in name:
+        if caching_types.valid_cached_content_name(name):
             name = "cachedContents/" + name
+        else:
+            raise ValueError(caching_types.NAME_ERROR_MESSAGE.format(name=name))
 
         if "/" not in model:
             model = "models/" + model

--- a/google/generativeai/caching.py
+++ b/google/generativeai/caching.py
@@ -61,7 +61,7 @@ class CachedContent:
             value = self.expire_time + datetime.timedelta(seconds=value["seconds"])
             parts[-1] = "expire_time"
         setattr(self, parts[-1], value)
-    
+
     @classmethod
     def _decode_cached_content(cls, cached_content: glm.CachedContent) -> CachedContent:
         # not supposed to get INPUT_ONLY repeated fields, but local gapic lib build
@@ -186,17 +186,15 @@ class CachedContent:
         request = glm.GetCachedContentRequest(name=name)
         response = client.get_cached_content(request)
         return cls._decode_cached_content(response)
-    
+
     @classmethod
     def list(
-        cls,
-        page_size: Optional[int] = 1,
-        client: glm.CacheServiceClient | None = None
+        cls, page_size: Optional[int] = 1, client: glm.CacheServiceClient | None = None
     ) -> Iterable[CachedContent]:
         """Lists `CachedContent` objects associated with the project.
 
         Args:
-            page_size: The maximum number of permissions to return (per page). 
+            page_size: The maximum number of permissions to return (per page).
             The service may return fewer `CachedContent` objects.
 
         Returns:

--- a/google/generativeai/caching.py
+++ b/google/generativeai/caching.py
@@ -14,63 +14,251 @@
 # limitations under the License.
 from __future__ import annotations
 
-from typing import Optional, Iterable
+import dataclasses
+import datetime
+from typing import Any, Iterable, Optional
 
-import google.ai.generativelanguage as glm
-
+from google.generativeai.types.model_types import idecode_time
 from google.generativeai.types import caching_types
 from google.generativeai.types import content_types
+from google.generativeai.utils import flatten_update_paths
 from google.generativeai.client import get_default_cache_client
 
-
-# alias for `caching_types.CachedContent`.
-CachedContent = caching_types.CachedContent
-
-
-def get_cached_content(name: str, client: glm.CacheServiceClient | None = None) -> CachedContent:
-    """Fetches required `CachedContent` resource.
-
-    Args:
-        name: name: The resource name referring to the cached content.
-
-    Returns:
-        `CachedContent` resource with specified name.
-    """
-    return CachedContent.get(name=name, client=client)
+from google.protobuf import field_mask_pb2
+import google.ai.generativelanguage as glm
 
 
-def delete_cached_content(name: str, client: glm.CacheServiceClient | None = None) -> None:
-    """Deletes `CachedContent` resource.
+@dataclasses.dataclass
+class CachedContent:
+    """Cached content resource."""
 
-    Args:
-        name: The resource name referring to the cached content.
-              Format: cachedContents/{id}.
-    """
-    if client is None:
-        client = get_default_cache_client()
+    name: str
+    model: str
+    create_time: datetime.datetime
+    update_time: datetime.datetime
+    expire_time: datetime.datetime
 
-    if "cachedContents/" not in name:
-        name = "cachedContents/" + name
+    # NOTE: Automatic CachedContent deletion using contextmanager is not P0(P1+).
+    # Adding basic support for now.
+    def __enter__(self):
+        return self
 
-    request = glm.DeleteCachedContentRequest(name=name)
-    client.delete_cached_content(request)
-    return
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        self.delete()
 
+    def _to_dict(self) -> glm.CachedContent:
+        proto_paths = {
+            "name": self.name,
+            "model": self.model,
+        }
+        return glm.CachedContent(**proto_paths)
 
-def list_cached_contents(
-    page_size: Optional[int] = 1, client: glm.CacheServiceClient | None = None
-) -> Iterable[CachedContent]:
-    """Lists `CachedContent` objects associated with the project.
+    def _apply_update(self, path, value):
+        parts = path.split(".")
+        for part in parts[:-1]:
+            self = getattr(self, part)
+        if parts[-1] == "ttl":
+            value = self.expire_time + datetime.timedelta(seconds=value["seconds"])
+            parts[-1] = "expire_time"
+        setattr(self, parts[-1], value)
+    
+    @classmethod
+    def _decode_cached_content(cls, cached_content: glm.CachedContent) -> CachedContent:
+        # not supposed to get INPUT_ONLY repeated fields, but local gapic lib build
+        # is returning these, hence setting including_default_value_fields to False
+        cached_content = type(cached_content).to_dict(
+            cached_content, including_default_value_fields=False
+        )
 
-    Args:
-        page_size: The maximum number of permissions to return (per page). The service may return fewer `CachedContent` objects.
+        idecode_time(cached_content, "create_time")
+        idecode_time(cached_content, "update_time")
+        # always decode `expire_time` as Timestamp is returned
+        # regardless of what was sent on input
+        idecode_time(cached_content, "expire_time")
+        return cls(**cached_content)
 
-    Returns:
-        A paginated list of `CachedContent` objects.
-    """
-    if client is None:
-        client = get_default_cache_client()
+    @staticmethod
+    def _prepare_create_request(
+        name: str,
+        model: str,
+        system_instruction: Optional[content_types.ContentType] = None,
+        contents: Optional[content_types.ContentsType] = None,
+        tools: Optional[content_types.FunctionLibraryType] = None,
+        tool_config: Optional[content_types.ToolConfigType] = None,
+        ttl: Optional[caching_types.ExpirationTypes] = datetime.timedelta(hours=1),
+    ) -> glm.CreateCachedContentRequest:
+        """Prepares a CreateCachedContentRequest."""
+        if "cachedContents/" not in name:
+            name = "cachedContents/" + name
 
-    request = glm.ListCachedContentsRequest(page_size=page_size)
-    for cached_content in client.list_cached_contents(request):
-        yield caching_types.decode_cached_content(cached_content)
+        if "/" not in model:
+            model = "models/" + model
+
+        if system_instruction:
+            system_instruction = content_types.to_content(system_instruction)
+
+        tools_lib = content_types.to_function_library(tools)
+        if tools_lib:
+            tools_lib = tools_lib.to_proto()
+
+        if tool_config:
+            tool_config = content_types.to_tool_config(tool_config)
+
+        if contents:
+            contents = content_types.to_contents(contents)
+
+        if ttl:
+            ttl = caching_types.to_ttl(ttl)
+
+        cached_content = glm.CachedContent(
+            name=name,
+            model=model,
+            system_instruction=system_instruction,
+            contents=contents,
+            tools=tools_lib,
+            tool_config=tool_config,
+            ttl=ttl,
+        )
+
+        return glm.CreateCachedContentRequest(cached_content=cached_content)
+
+    @classmethod
+    def create(
+        cls,
+        name: str,
+        model: str,
+        system_instruction: Optional[content_types.ContentType] = None,
+        contents: Optional[content_types.ContentsType] = None,
+        tools: Optional[content_types.FunctionLibraryType] = None,
+        tool_config: Optional[content_types.ToolConfigType] = None,
+        ttl: Optional[caching_types.ExpirationTypes] = datetime.timedelta(hours=1),
+        client: glm.CacheServiceClient | None = None,
+    ) -> CachedContent:
+        """Creates CachedContent resource.
+
+        Args:
+            name: The resource name referring to the cached content.
+                  Format: cachedContents/{id}.
+            model: The name of the `Model` to use for cached content
+                    Format: models/{model}. Cached content resource can be only
+                    used with model it was created for.
+            system_instruction: Developer set system instruction.
+            contents: Contents to cache.
+            tools: A list of `Tools` the model may use to generate response.
+            tool_config: Config to apply to all tools.
+            ttl: TTL for cached resource (in seconds). Defaults to 1 hour.
+
+        Returns:
+            `CachedContent` resource with specified name.
+        """
+        if client is None:
+            client = get_default_cache_client()
+
+        request = cls._prepare_create_request(
+            name=name,
+            model=model,
+            system_instruction=system_instruction,
+            contents=contents,
+            tools=tools,
+            tool_config=tool_config,
+            ttl=ttl,
+        )
+
+        response = client.create_cached_content(request)
+        return cls._decode_cached_content(response)
+
+    @classmethod
+    def get(cls, name: str, client: glm.CacheServiceClient | None = None) -> CachedContent:
+        """Fetches required `CachedContent` resource.
+
+        Args:
+            name: name: The resource name referring to the cached content.
+
+        Returns:
+            `CachedContent` resource with specified name.
+        """
+        if client is None:
+            client = get_default_cache_client()
+
+        if "cachedContents/" not in name:
+            name = "cachedContents/" + name
+
+        request = glm.GetCachedContentRequest(name=name)
+        response = client.get_cached_content(request)
+        return cls._decode_cached_content(response)
+    
+    @classmethod
+    def list(
+        cls,
+        page_size: Optional[int] = 1,
+        client: glm.CacheServiceClient | None = None
+    ) -> Iterable[CachedContent]:
+        """Lists `CachedContent` objects associated with the project.
+
+        Args:
+            page_size: The maximum number of permissions to return (per page). 
+            The service may return fewer `CachedContent` objects.
+
+        Returns:
+            A paginated list of `CachedContent` objects.
+        """
+        if client is None:
+            client = get_default_cache_client()
+
+        request = glm.ListCachedContentsRequest(page_size=page_size)
+        for cached_content in client.list_cached_contents(request):
+            yield cls._decode_cached_content(cached_content)
+
+    def delete(self, client: glm.CachedServiceClient | None = None) -> None:
+        """Deletes `CachedContent` resource.
+
+        Args:
+            name: The resource name referring to the cached content.
+                Format: cachedContents/{id}.
+        """
+        if client is None:
+            client = get_default_cache_client()
+
+        request = glm.DeleteCachedContentRequest(name=self.name)
+        client.delete_cached_content(request)
+        return
+
+    def update(
+        self,
+        updates: dict[str, Any],
+        client: glm.CacheServiceClient | None = None,
+    ) -> CachedContent:
+        """Updates requested `CachedContent` resource.
+
+        Args:
+            updates: The list of fields to update.
+                     Currently only `ttl/expire_time` is supported as an update path.
+
+        Returns:
+            `CachedContent` object with specified updates.
+        """
+        if client is None:
+            client = get_default_cache_client()
+
+        updates = flatten_update_paths(updates)
+        for update_path in updates:
+            if update_path == "ttl":
+                updates = updates.copy()
+                update_path_val = updates.get(update_path)
+                updates[update_path] = caching_types.to_ttl(update_path_val)
+            else:
+                raise ValueError(
+                    f"As of now, only `ttl` can be updated for `CachedContent`. Got: `{update_path}` instead."
+                )
+        field_mask = field_mask_pb2.FieldMask()
+
+        for path in updates.keys():
+            field_mask.paths.append(path)
+        for path, value in updates.items():
+            self._apply_update(path, value)
+
+        request = glm.UpdateCachedContentRequest(
+            cached_content=self._to_dict(), update_mask=field_mask
+        )
+        client.update_cached_content(request)
+        return self

--- a/google/generativeai/client.py
+++ b/google/generativeai/client.py
@@ -289,6 +289,10 @@ _client_manager = _ClientManager()
 _client_manager.configure()
 
 
+def get_default_cache_client() -> glm.CacheServiceClient:
+    return _client_manager.get_default_client("cache")
+
+
 def get_default_discuss_client() -> glm.DiscussServiceClient:
     return _client_manager.get_default_client("discuss")
 

--- a/google/generativeai/generative_models.py
+++ b/google/generativeai/generative_models.py
@@ -20,6 +20,7 @@ from google.generativeai.types import generation_types
 from google.generativeai.types import helper_types
 from google.generativeai.types import safety_types
 
+
 class GenerativeModel:
     """
     The `genai.GenerativeModel` class wraps default parameters for calls to

--- a/google/generativeai/generative_models.py
+++ b/google/generativeai/generative_models.py
@@ -123,6 +123,7 @@ class GenerativeModel:
                 safety_settings={self._safety_settings},
                 tools={self._tools},
                 system_instruction={maybe_text(self._system_instruction)},
+                cached_content={getattr(self, "cached_content", None)}
             )"""
         )
 

--- a/google/generativeai/generative_models.py
+++ b/google/generativeai/generative_models.py
@@ -96,7 +96,7 @@ class GenerativeModel:
         self._client = None
         self._async_client = None
 
-    def __new__(cls, *args, **kwargs):
+    def __new__(cls, *args, **kwargs) -> GenerativeModel:
         self = super().__new__(cls)
 
         if cached_instance := kwargs.pop("cached_content", None):

--- a/google/generativeai/generative_models.py
+++ b/google/generativeai/generative_models.py
@@ -19,8 +19,6 @@ from google.generativeai.types import content_types
 from google.generativeai.types import generation_types
 from google.generativeai.types import helper_types
 from google.generativeai.types import safety_types
-from google.generativeai.types import caching_types
-
 
 class GenerativeModel:
     """
@@ -198,7 +196,7 @@ class GenerativeModel:
     @classmethod
     def from_cached_content(
         cls,
-        cached_content: caching_types.CachedContent,
+        cached_content: caching.CachedContent,
         generation_config: generation_types.GenerationConfigType | None = None,
         safety_settings: safety_types.SafetySettingOptions | None = None,
     ) -> GenerativeModel: ...
@@ -206,7 +204,7 @@ class GenerativeModel:
     @classmethod
     def from_cached_content(
         cls,
-        cached_content: str | caching_types.CachedContent,
+        cached_content: str | caching.CachedContent,
         generation_config: generation_types.GenerationConfigType | None = None,
         safety_settings: safety_types.SafetySettingOptions | None = None,
     ) -> GenerativeModel:
@@ -219,7 +217,7 @@ class GenerativeModel:
             `GenerativeModel` object with `cached_content` as its context.
         """
         if isinstance(cached_content, str):
-            cached_content = caching.get_cached_content(name=cached_content)
+            cached_content = caching.CachedContent.get(name=cached_content)
 
         # call __new__ with the cached_content to set the model's context. This is done to avoid
         # the exposing `cached_content` as a public attribute.

--- a/google/generativeai/types/caching_types.py
+++ b/google/generativeai/types/caching_types.py
@@ -27,6 +27,7 @@ class TTL(TypedDict):
 
 ExpirationTypes = Union[TTL, int, datetime.timedelta]
 
+
 def to_ttl(expiration: Optional[ExpirationTypes]) -> TTL:
     if isinstance(expiration, datetime.timedelta):
         return {"seconds": int(expiration.total_seconds())}

--- a/google/generativeai/types/caching_types.py
+++ b/google/generativeai/types/caching_types.py
@@ -14,22 +14,11 @@
 # limitations under the License.
 from __future__ import annotations
 
-import dataclasses
 import datetime
 from typing import Optional, Union
 from typing_extensions import TypedDict
 
-from google.generativeai.types import content_types
-from google.generativeai.types.model_types import idecode_time
-from google.generativeai.utils import flatten_update_paths
-from google.generativeai.client import get_default_cache_client
-
-from google.protobuf import field_mask_pb2
-
-import google.ai.generativelanguage as glm
-
-
-__all__ = ["CachedContent"]
+__all__ = ["TTL"]
 
 
 class TTL(TypedDict):
@@ -38,8 +27,7 @@ class TTL(TypedDict):
 
 ExpirationTypes = Union[TTL, int, datetime.timedelta]
 
-
-def _to_ttl(expiration: Optional[ExpirationTypes]) -> TTL:
+def to_ttl(expiration: Optional[ExpirationTypes]) -> TTL:
     if isinstance(expiration, datetime.timedelta):
         return {"seconds": int(expiration.total_seconds())}
     elif isinstance(expiration, dict):
@@ -51,205 +39,3 @@ def _to_ttl(expiration: Optional[ExpirationTypes]) -> TTL:
             f"Could not convert input to `expire_time` \n'" f"  type: {type(expiration)}\n",
             expiration,
         )
-
-
-def decode_cached_content(cached_content: glm.CachedContent) -> CachedContent:
-    # not supposed to get INPUT_ONLY repeated fields, but local gapic lib build
-    # is returning these, hence setting including_default_value_fields to False
-    cached_content = type(cached_content).to_dict(
-        cached_content, including_default_value_fields=False
-    )
-
-    idecode_time(cached_content, "create_time")
-    idecode_time(cached_content, "update_time")
-    # always decode `expire_time` as Timestamp is returned
-    # regardless of what was sent on input
-    idecode_time(cached_content, "expire_time")
-    return CachedContent(**cached_content)
-
-
-@dataclasses.dataclass
-class CachedContent:
-    """Cached content resource."""
-
-    name: str
-    model: str
-    create_time: datetime.datetime
-    update_time: datetime.datetime
-    expire_time: datetime.datetime
-
-    # NOTE: Automatic CachedContent deletion using contextmanager is not P0(P1+).
-    # Adding basic support for now.
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_value, exc_tb):
-        self.delete()
-
-    def _to_dict(self) -> glm.CachedContent:
-        proto_paths = {
-            "name": self.name,
-            "model": self.model,
-        }
-        return glm.CachedContent(**proto_paths)
-
-    def _apply_update(self, path, value):
-        parts = path.split(".")
-        for part in parts[:-1]:
-            self = getattr(self, part)
-        if parts[-1] == "ttl":
-            value = self.expire_time + datetime.timedelta(seconds=value["seconds"])
-            parts[-1] = "expire_time"
-        setattr(self, parts[-1], value)
-
-    @staticmethod
-    def _prepare_create_request(
-        name: str,
-        model: str,
-        system_instruction: Optional[content_types.ContentType] = None,
-        contents: Optional[content_types.ContentsType] = None,
-        tools: Optional[content_types.FunctionLibraryType] = None,
-        tool_config: Optional[content_types.ToolConfigType] = None,
-        ttl: Optional[ExpirationTypes] = datetime.timedelta(hours=1),
-    ) -> glm.CreateCachedContentRequest:
-        """Prepares a CreateCachedContentRequest."""
-        if "cachedContents/" not in name:
-            name = "cachedContents/" + name
-
-        if "/" not in model:
-            model = "models/" + model
-
-        if system_instruction:
-            system_instruction = content_types.to_content(system_instruction)
-
-        tools_lib = content_types.to_function_library(tools)
-        if tools_lib:
-            tools_lib = tools_lib.to_proto()
-
-        if tool_config:
-            tool_config = content_types.to_tool_config(tool_config)
-
-        if contents:
-            contents = content_types.to_contents(contents)
-
-        if ttl:
-            ttl = _to_ttl(ttl)
-
-        cached_content = glm.CachedContent(
-            name=name,
-            model=model,
-            system_instruction=system_instruction,
-            contents=contents,
-            tools=tools_lib,
-            tool_config=tool_config,
-            ttl=ttl,
-        )
-
-        return glm.CreateCachedContentRequest(cached_content=cached_content)
-
-    @classmethod
-    def create(
-        cls,
-        name: str,
-        model: str,
-        system_instruction: Optional[content_types.ContentType] = None,
-        contents: Optional[content_types.ContentsType] = None,
-        tools: Optional[content_types.FunctionLibraryType] = None,
-        tool_config: Optional[content_types.ToolConfigType] = None,
-        ttl: Optional[ExpirationTypes] = datetime.timedelta(hours=1),
-        client: glm.CacheServiceClient | None = None,
-    ) -> CachedContent:
-        """Creates CachedContent resource.
-
-        Args:
-            name: The resource name referring to the cached content.
-                  Format: cachedContents/{id}.
-            model: The name of the `Model` to use for cached content
-                    Format: models/{model}. Cached content resource can be only
-                    used with model it was created for.
-            system_instruction: Developer set system instruction.
-            contents: Contents to cache.
-            tools: A list of `Tools` the model may use to generate response.
-            tool_config: Config to apply to all tools.
-            ttl: TTL for cached resource (in seconds). Defaults to 1 hour.
-
-        Returns:
-            `CachedContent` resource with specified name.
-        """
-        if client is None:
-            client = get_default_cache_client()
-
-        request = cls._prepare_create_request(
-            name=name,
-            model=model,
-            system_instruction=system_instruction,
-            contents=contents,
-            tools=tools,
-            tool_config=tool_config,
-            ttl=ttl,
-        )
-
-        response = client.create_cached_content(request)
-        return decode_cached_content(response)
-
-    @classmethod
-    def get(cls, name: str, client: glm.CacheServiceClient | None = None) -> CachedContent:
-        """Gets a `CachedContent` resource."""
-        if client is None:
-            client = get_default_cache_client()
-
-        if "cachedContents/" not in name:
-            name = "cachedContents/" + name
-
-        request = glm.GetCachedContentRequest(name=name)
-        response = client.get_cached_content(request)
-        return decode_cached_content(response)
-
-    def delete(self, client: glm.CachedServiceClient | None = None) -> None:
-        """Deletes a `CachedContent` resource."""
-        if client is None:
-            client = get_default_cache_client()
-
-        request = glm.DeleteCachedContentRequest(name=self.name)
-        client.delete_cached_content(request)
-        return
-
-    def update(
-        self,
-        updates: dict[str, Any],
-        client: glm.CacheServiceClient | None = None,
-    ) -> CachedContent:
-        """Updates requested `CachedContent` resource.
-
-        Args:
-            updates: The list of fields to update.
-                     Currently only `ttl/expire_time` is supported as an update path.
-
-        Returns:
-            `CachedContent` object with specified updates.
-        """
-        if client is None:
-            client = get_default_cache_client()
-
-        updates = flatten_update_paths(updates)
-        for update_path in updates:
-            if update_path == "ttl":
-                updates = updates.copy()
-                update_path_val = updates.get(update_path)
-                updates[update_path] = _to_ttl(update_path_val)
-            else:
-                raise ValueError(
-                    f"As of now, only `ttl` can be updated for `CachedContent`. Got: `{update_path}` instead."
-                )
-        field_mask = field_mask_pb2.FieldMask()
-
-        for path in updates.keys():
-            field_mask.paths.append(path)
-        for path, value in updates.items():
-            self._apply_update(path, value)
-
-        request = glm.UpdateCachedContentRequest(
-            cached_content=self._to_dict(), update_mask=field_mask
-        )
-        client.update_cached_content(request)
-        return self

--- a/google/generativeai/types/caching_types.py
+++ b/google/generativeai/types/caching_types.py
@@ -17,8 +17,19 @@ from __future__ import annotations
 import datetime
 from typing import Optional, Union
 from typing_extensions import TypedDict
+import re
 
 __all__ = ["TTL"]
+
+
+_VALID_CACHED_CONTENT_NAME = r"([a-z0-9-\.]+)$"
+NAME_ERROR_MESSAGE = (
+    "The `name` must consist of alphanumeric characters (or `-` or `.`). Received: `{name}`"
+)
+
+
+def valid_cached_content_name(name: str) -> bool:
+    return re.match(_VALID_CACHED_CONTENT_NAME, name) is not None
 
 
 class TTL(TypedDict):

--- a/google/generativeai/types/caching_types.py
+++ b/google/generativeai/types/caching_types.py
@@ -1,0 +1,257 @@
+# -*- coding: utf-8 -*-
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import dataclasses
+import datetime
+from typing import Optional, Union
+from typing_extensions import TypedDict
+
+from google.generativeai.types import content_types
+from google.generativeai.types.model_types import idecode_time
+from google.generativeai.utils import flatten_update_paths
+from google.generativeai.client import get_default_cache_client
+
+from google.protobuf import field_mask_pb2
+
+import google.ai.generativelanguage as glm
+
+
+__all__ = ["CachedContent"]
+
+
+class TTL(TypedDict):
+    seconds: int
+
+
+ExpirationTypes = Union[TTL, int, datetime.timedelta]
+
+
+def _to_ttl(expiration: Optional[ExpirationTypes]) -> TTL:
+    if isinstance(expiration, datetime.timedelta):
+        return {"seconds": int(expiration.total_seconds())}
+    elif isinstance(expiration, dict):
+        return expiration
+    elif isinstance(expiration, int):
+        return {"seconds": expiration}
+    else:
+        raise TypeError(
+            f"Could not convert input to `expire_time` \n'" f"  type: {type(expiration)}\n",
+            expiration,
+        )
+
+
+def decode_cached_content(cached_content: glm.CachedContent) -> CachedContent:
+    # not supposed to get INPUT_ONLY repeated fields, but local gapic lib build
+    # is returning these, hence setting including_default_value_fields to False
+    cached_content = type(cached_content).to_dict(
+        cached_content, including_default_value_fields=False
+    )
+
+    idecode_time(cached_content, "create_time")
+    idecode_time(cached_content, "update_time")
+    # always decode `expire_time` as Timestamp is returned
+    # regardless of what was sent on input
+    idecode_time(cached_content, "expire_time")
+    return CachedContent(**cached_content)
+
+
+@dataclasses.dataclass
+class CachedContent:
+    """Cached content resource."""
+
+    name: str
+    model: str
+    create_time: datetime.datetime
+    update_time: datetime.datetime
+    expire_time: datetime.datetime
+
+    # NOTE: Automatic CachedContent deletion using contextmanager is not P0(P1+).
+    # Adding basic support for now.
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        self.delete()
+
+    def _to_dict(self) -> glm.CachedContent:
+        proto_paths = {
+            "name": self.name,
+            "model": self.model,
+        }
+        return glm.CachedContent(**proto_paths)
+
+    def _apply_update(self, path, value):
+        parts = path.split(".")
+        for part in parts[:-1]:
+            self = getattr(self, part)
+        if parts[-1] == "ttl":
+            value = self.expire_time + datetime.timedelta(seconds=value["seconds"])
+            parts[-1] = "expire_time"
+        setattr(self, parts[-1], value)
+
+    @staticmethod
+    def _prepare_create_request(
+        name: str,
+        model: str,
+        system_instruction: Optional[content_types.ContentType] = None,
+        contents: Optional[content_types.ContentsType] = None,
+        tools: Optional[content_types.FunctionLibraryType] = None,
+        tool_config: Optional[content_types.ToolConfigType] = None,
+        ttl: Optional[ExpirationTypes] = datetime.timedelta(hours=1),
+    ) -> glm.CreateCachedContentRequest:
+        """Prepares a CreateCachedContentRequest."""
+        if "cachedContents/" not in name:
+            name = "cachedContents/" + name
+
+        if "/" not in model:
+            model = "models/" + model
+
+        if system_instruction:
+            system_instruction = content_types.to_content(system_instruction)
+
+        tools_lib = content_types.to_function_library(tools)
+        if tools_lib:
+            tools_lib = tools_lib.to_proto()
+
+        if tool_config:
+            tool_config = content_types.to_tool_config(tool_config)
+
+        if contents:
+            contents = content_types.to_contents(contents)
+
+        if ttl:
+            ttl = _to_ttl(ttl)
+
+        cached_content = glm.CachedContent(
+            name=name,
+            model=model,
+            system_instruction=system_instruction,
+            contents=contents,
+            tools=tools_lib,
+            tool_config=tool_config,
+            ttl=ttl,
+        )
+
+        return glm.CreateCachedContentRequest(cached_content=cached_content)
+
+    @classmethod
+    def create(
+        cls,
+        name: str,
+        model: str,
+        system_instruction: Optional[content_types.ContentType] = None,
+        contents: Optional[content_types.ContentsType] = None,
+        tools: Optional[content_types.FunctionLibraryType] = None,
+        tool_config: Optional[content_types.ToolConfigType] = None,
+        ttl: Optional[ExpirationTypes] = datetime.timedelta(hours=1),
+        client: glm.CacheServiceClient | None = None,
+    ) -> CachedContent:
+        """Creates CachedContent resource.
+
+        Args:
+            name: The resource name referring to the cached content.
+                  Format: cachedContents/{id}.
+            model: The name of the `Model` to use for cached content
+                    Format: models/{model}. Cached content resource can be only
+                    used with model it was created for.
+            system_instruction: Developer set system instruction.
+            contents: Contents to cache.
+            tools: A list of `Tools` the model may use to generate response.
+            tool_config: Config to apply to all tools.
+            ttl: TTL for cached resource (in seconds). Defaults to 1 hour.
+
+        Returns:
+            `CachedContent` resource with specified name.
+        """
+        if client is None:
+            client = get_default_cache_client()
+
+        request = cls._prepare_create_request(
+            name=name,
+            model=model,
+            system_instruction=system_instruction,
+            contents=contents,
+            tools=tools,
+            tool_config=tool_config,
+            ttl=ttl,
+        )
+
+        response = client.create_cached_content(request)
+        return decode_cached_content(response)
+
+    @classmethod
+    def get_cached_content(
+        cls, name: str, client: glm.CacheServiceClient | None = None
+    ) -> CachedContent:
+        """Gets a `CachedContent` resource."""
+        if client is None:
+            client = get_default_cache_client()
+
+        if "cachedContents/" not in name:
+            name = "cachedContents/" + name
+
+        request = glm.GetCachedContentRequest(name=name)
+        response = client.get_cached_content(request)
+        return decode_cached_content(response)
+
+    def delete(self, client: glm.CachedServiceClient | None = None) -> None:
+        """Deletes a `CachedContent` resource."""
+        if client is None:
+            client = get_default_cache_client()
+
+        request = glm.DeleteCachedContentRequest(name=self.name)
+        client.delete_cached_content(request)
+        return
+
+    def update(
+        self,
+        updates: dict[str, Any],
+        client: glm.CacheServiceClient | None = None,
+    ) -> CachedContent:
+        """Updates requested `CachedContent` resource.
+
+        Args:
+            updates: The list of fields to update.
+                     Currently only `ttl/expire_time` is supported as an update path.
+
+        Returns:
+            `CachedContent` object with specified updates.
+        """
+        if client is None:
+            client = get_default_cache_client()
+
+        updates = flatten_update_paths(updates)
+        for update_path in updates:
+            if update_path == "ttl":
+                updates = updates.copy()
+                update_path_val = updates.get(update_path)
+                updates[update_path] = _to_ttl(update_path_val)
+            else:
+                raise ValueError(
+                    f"As of now, only `ttl` can be updated for `CachedContent`. Got: `{update_path}` instead."
+                )
+        field_mask = field_mask_pb2.FieldMask()
+
+        for path in updates.keys():
+            field_mask.paths.append(path)
+        for path, value in updates.items():
+            self._apply_update(path, value)
+
+        request = glm.UpdateCachedContentRequest(
+            cached_content=self._to_dict(), update_mask=field_mask
+        )
+        client.update_cached_content(request)
+        return self

--- a/google/generativeai/types/caching_types.py
+++ b/google/generativeai/types/caching_types.py
@@ -193,9 +193,7 @@ class CachedContent:
         return decode_cached_content(response)
 
     @classmethod
-    def get_cached_content(
-        cls, name: str, client: glm.CacheServiceClient | None = None
-    ) -> CachedContent:
+    def get(cls, name: str, client: glm.CacheServiceClient | None = None) -> CachedContent:
         """Gets a `CachedContent` resource."""
         if client is None:
             client = get_default_cache_client()

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ else:
     release_status = "Development Status :: 5 - Production/Stable"
 
 dependencies = [
-    "google-ai-generativelanguage==0.6.4",
+    "google-ai-generativelanguage@https://storage.googleapis.com/generativeai-downloads/preview/ai-generativelanguage-v1beta-py.tar.gz",
     "google-api-core",
     "google-api-python-client",
     "google-auth>=2.15.0",  # 2.15 adds API key auth support

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,17 +12,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import copy
-import math
 import datetime
-from typing import Any
 import unittest
-import unittest.mock as mock
-
-import google.ai.generativelanguage as glm
 
 from google.generativeai import caching
-from google.generativeai.types import caching_types
+from google.generativeai import protos
 
 from google.generativeai import client
 from absl.testing import absltest
@@ -44,11 +38,11 @@ class UnitTests(parameterized.TestCase):
 
         @add_client_method
         def create_cached_content(
-            request: glm.CreateCachedContentRequest,
+            request: protos.CreateCachedContentRequest,
             **kwargs,
-        ) -> glm.CachedContent:
+        ) -> protos.CachedContent:
             self.observed_requests.append(request)
-            return glm.CachedContent(
+            return protos.CachedContent(
                 name="cachedContents/test-cached-content",
                 model="models/gemini-1.0-pro-001",
                 create_time="2000-01-01T01:01:01.123456Z",
@@ -58,11 +52,11 @@ class UnitTests(parameterized.TestCase):
 
         @add_client_method
         def get_cached_content(
-            request: glm.GetCachedContentRequest,
+            request: protos.GetCachedContentRequest,
             **kwargs,
-        ) -> glm.CachedContent:
+        ) -> protos.CachedContent:
             self.observed_requests.append(request)
-            return glm.CachedContent(
+            return protos.CachedContent(
                 name="cachedContents/test-cached-content",
                 model="models/gemini-1.0-pro-001",
                 create_time="2000-01-01T01:01:01.123456Z",
@@ -72,19 +66,19 @@ class UnitTests(parameterized.TestCase):
 
         @add_client_method
         def list_cached_contents(
-            request: glm.ListCachedContentsRequest,
+            request: protos.ListCachedContentsRequest,
             **kwargs,
-        ) -> glm.ListCachedContentsResponse:
+        ) -> protos.ListCachedContentsResponse:
             self.observed_requests.append(request)
             return [
-                glm.CachedContent(
+                protos.CachedContent(
                     name="cachedContents/test-cached-content-1",
                     model="models/gemini-1.0-pro-001",
                     create_time="2000-01-01T01:01:01.123456Z",
                     update_time="2000-01-01T01:01:01.123456Z",
                     expire_time="2000-01-01T01:01:01.123456Z",
                 ),
-                glm.CachedContent(
+                protos.CachedContent(
                     name="cachedContents/test-cached-content-2",
                     model="models/gemini-1.0-pro-001",
                     create_time="2000-01-01T01:01:01.123456Z",
@@ -95,11 +89,11 @@ class UnitTests(parameterized.TestCase):
 
         @add_client_method
         def update_cached_content(
-            request: glm.UpdateCachedContentRequest,
+            request: protos.UpdateCachedContentRequest,
             **kwargs,
-        ) -> glm.CachedContent:
+        ) -> protos.CachedContent:
             self.observed_requests.append(request)
-            return glm.CachedContent(
+            return protos.CachedContent(
                 name="cachedContents/test-cached-content",
                 model="models/gemini-1.0-pro-001",
                 create_time="2000-01-01T01:01:01.123456Z",
@@ -109,7 +103,7 @@ class UnitTests(parameterized.TestCase):
 
         @add_client_method
         def delete_cached_content(
-            request: glm.DeleteCachedContentRequest,
+            request: protos.DeleteCachedContentRequest,
             **kwargs,
         ) -> None:
             self.observed_requests.append(request)
@@ -128,7 +122,7 @@ class UnitTests(parameterized.TestCase):
             system_instruction="Always add 10 to the result.",
             ttl=datetime.timedelta(minutes=30),
         )
-        self.assertIsInstance(self.observed_requests[-1], glm.CreateCachedContentRequest)
+        self.assertIsInstance(self.observed_requests[-1], protos.CreateCachedContentRequest)
         self.assertIsInstance(cc, caching.CachedContent)
         self.assertEqual(cc.name, "cachedContents/test-cached-content")
         self.assertEqual(cc.model, "models/gemini-1.0-pro-001")
@@ -160,7 +154,7 @@ class UnitTests(parameterized.TestCase):
             contents=["cache this please for 2 hours"],
             ttl=ttl,
         )
-        self.assertIsInstance(self.observed_requests[-1], glm.CreateCachedContentRequest)
+        self.assertIsInstance(self.observed_requests[-1], protos.CreateCachedContentRequest)
         self.assertIsInstance(cc, caching.CachedContent)
 
     @parameterized.named_parameters(
@@ -192,14 +186,14 @@ class UnitTests(parameterized.TestCase):
 
     def test_get_cached_content(self):
         cc = caching.CachedContent.get(name="cachedContents/test-cached-content")
-        self.assertIsInstance(self.observed_requests[-1], glm.GetCachedContentRequest)
+        self.assertIsInstance(self.observed_requests[-1], protos.GetCachedContentRequest)
         self.assertIsInstance(cc, caching.CachedContent)
         self.assertEqual(cc.name, "cachedContents/test-cached-content")
         self.assertEqual(cc.model, "models/gemini-1.0-pro-001")
 
     def test_list_cached_contents(self):
         ccs = list(caching.CachedContent.list(page_size=2))
-        self.assertIsInstance(self.observed_requests[-1], glm.ListCachedContentsRequest)
+        self.assertIsInstance(self.observed_requests[-1], protos.ListCachedContentsRequest)
         self.assertLen(ccs, 2)
         self.assertIsInstance(ccs[0], caching.CachedContent)
         self.assertIsInstance(ccs[1], caching.CachedContent)
@@ -223,17 +217,17 @@ class UnitTests(parameterized.TestCase):
 
         cc = caching.CachedContent.get(name="cachedContents/test-cached-content")
         cc = cc.update(updates=update_masks)
-        self.assertIsInstance(self.observed_requests[-1], glm.UpdateCachedContentRequest)
+        self.assertIsInstance(self.observed_requests[-1], protos.UpdateCachedContentRequest)
         self.assertIsInstance(cc, caching.CachedContent)
 
     def test_delete_cached_content(self):
         cc = caching.CachedContent.get(name="cachedContents/test-cached-content")
         cc.delete()
-        self.assertIsInstance(self.observed_requests[-1], glm.DeleteCachedContentRequest)
+        self.assertIsInstance(self.observed_requests[-1], protos.DeleteCachedContentRequest)
 
         cc = caching.CachedContent.get(name="cachedContents/test-cached-content")
         cc.delete()
-        self.assertIsInstance(self.observed_requests[-1], glm.DeleteCachedContentRequest)
+        self.assertIsInstance(self.observed_requests[-1], protos.DeleteCachedContentRequest)
 
     def test_auto_delete_cached_content_with_context_manager(self):
         with caching.CachedContent.create(
@@ -245,7 +239,7 @@ class UnitTests(parameterized.TestCase):
         ) as cc:
             ...  # some logic
 
-        self.assertIsInstance(self.observed_requests[-1], glm.DeleteCachedContentRequest)
+        self.assertIsInstance(self.observed_requests[-1], protos.DeleteCachedContentRequest)
 
 
 if __name__ == "__main__":

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -129,7 +129,7 @@ class UnitTests(parameterized.TestCase):
             ttl=datetime.timedelta(minutes=30),
         )
         self.assertIsInstance(self.observed_requests[-1], glm.CreateCachedContentRequest)
-        self.assertIsInstance(cc, caching_types.CachedContent)
+        self.assertIsInstance(cc, caching.CachedContent)
         self.assertEqual(cc.name, "cachedContent/test-cached-content")
         self.assertEqual(cc.model, "models/gemini-1.0-pro-001")
 
@@ -161,21 +161,21 @@ class UnitTests(parameterized.TestCase):
             ttl=ttl,
         )
         self.assertIsInstance(self.observed_requests[-1], glm.CreateCachedContentRequest)
-        self.assertIsInstance(cc, caching_types.CachedContent)
+        self.assertIsInstance(cc, caching.CachedContent)
 
     def test_get_cached_content(self):
-        cc = caching.get_cached_content(name="cachedContent/test-cached-content")
+        cc = caching.CachedContent.get(name="cachedContent/test-cached-content")
         self.assertIsInstance(self.observed_requests[-1], glm.GetCachedContentRequest)
-        self.assertIsInstance(cc, caching_types.CachedContent)
+        self.assertIsInstance(cc, caching.CachedContent)
         self.assertEqual(cc.name, "cachedContent/test-cached-content")
         self.assertEqual(cc.model, "models/gemini-1.0-pro-001")
 
     def test_list_cached_contents(self):
-        ccs = list(caching.list_cached_contents(page_size=2))
+        ccs = list(caching.CachedContent.list(page_size=2))
         self.assertIsInstance(self.observed_requests[-1], glm.ListCachedContentsRequest)
         self.assertLen(ccs, 2)
-        self.assertIsInstance(ccs[0], caching_types.CachedContent)
-        self.assertIsInstance(ccs[1], caching_types.CachedContent)
+        self.assertIsInstance(ccs[0], caching.CachedContent)
+        self.assertIsInstance(ccs[1], caching.CachedContent)
 
     def test_update_cached_content_invalid_update_paths(self):
         update_masks = dict(
@@ -185,7 +185,7 @@ class UnitTests(parameterized.TestCase):
             contents=["add this Content"],
         )
 
-        cc = caching.get_cached_content(name="cachedContent/test-cached-content")
+        cc = caching.CachedContent.get(name="cachedContent/test-cached-content")
         with self.assertRaises(ValueError):
             cc.update(updates=update_masks)
 
@@ -194,13 +194,13 @@ class UnitTests(parameterized.TestCase):
             ttl=datetime.timedelta(hours=2),
         )
 
-        cc = caching.get_cached_content(name="cachedContent/test-cached-content")
+        cc = caching.CachedContent.get(name="cachedContent/test-cached-content")
         cc = cc.update(updates=update_masks)
         self.assertIsInstance(self.observed_requests[-1], glm.UpdateCachedContentRequest)
-        self.assertIsInstance(cc, caching_types.CachedContent)
+        self.assertIsInstance(cc, caching.CachedContent)
 
     def test_delete_cached_content(self):
-        cc = caching.get_cached_content(name="cachedContent/test-cached-content")
+        cc = caching.CachedContent.get(name="cachedContent/test-cached-content")
         cc.delete()
         self.assertIsInstance(self.observed_requests[-1], glm.DeleteCachedContentRequest)
 

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -1,0 +1,224 @@
+# -*- coding: utf-8 -*-
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import copy
+import math
+import datetime
+from typing import Any
+import unittest
+import unittest.mock as mock
+
+import google.ai.generativelanguage as glm
+
+from google.generativeai import caching
+from google.generativeai.types import caching_types
+
+from google.generativeai import client
+from absl.testing import absltest
+from absl.testing import parameterized
+
+
+class UnitTests(parameterized.TestCase):
+    def setUp(self):
+        self.client = unittest.mock.MagicMock()
+
+        client._client_manager.clients["cache"] = self.client
+
+        self.observed_requests = []
+
+        def add_client_method(f):
+            name = f.__name__
+            setattr(self.client, name, f)
+            return f
+
+        @add_client_method
+        def create_cached_content(
+            request: glm.CreateCachedContentRequest,
+            **kwargs,
+        ) -> glm.CachedContent:
+            self.observed_requests.append(request)
+            return glm.CachedContent(
+                name="cachedContent/test-cached-content",
+                model="models/gemini-1.0-pro-001",
+                create_time="2000-01-01T01:01:01.123456Z",
+                update_time="2000-01-01T01:01:01.123456Z",
+                expire_time="2000-01-01T01:01:01.123456Z",
+            )
+
+        @add_client_method
+        def get_cached_content(
+            request: glm.GetCachedContentRequest,
+            **kwargs,
+        ) -> glm.CachedContent:
+            self.observed_requests.append(request)
+            return glm.CachedContent(
+                name="cachedContent/test-cached-content",
+                model="models/gemini-1.0-pro-001",
+                create_time="2000-01-01T01:01:01.123456Z",
+                update_time="2000-01-01T01:01:01.123456Z",
+                expire_time="2000-01-01T01:01:01.123456Z",
+            )
+
+        @add_client_method
+        def list_cached_contents(
+            request: glm.ListCachedContentsRequest,
+            **kwargs,
+        ) -> glm.ListCachedContentsResponse:
+            self.observed_requests.append(request)
+            return [
+                glm.CachedContent(
+                    name="cachedContent/test-cached-content-1",
+                    model="models/gemini-1.0-pro-001",
+                    create_time="2000-01-01T01:01:01.123456Z",
+                    update_time="2000-01-01T01:01:01.123456Z",
+                    expire_time="2000-01-01T01:01:01.123456Z",
+                ),
+                glm.CachedContent(
+                    name="cachedContent/test-cached-content-2",
+                    model="models/gemini-1.0-pro-001",
+                    create_time="2000-01-01T01:01:01.123456Z",
+                    update_time="2000-01-01T01:01:01.123456Z",
+                    expire_time="2000-01-01T01:01:01.123456Z",
+                ),
+            ]
+
+        @add_client_method
+        def update_cached_content(
+            request: glm.UpdateCachedContentRequest,
+            **kwargs,
+        ) -> glm.CachedContent:
+            self.observed_requests.append(request)
+            return glm.CachedContent(
+                name="cachedContent/test-cached-content",
+                model="models/gemini-1.0-pro-001",
+                create_time="2000-01-01T01:01:01.123456Z",
+                update_time="2000-01-01T01:01:01.123456Z",
+                expire_time="2000-01-01T03:01:01.123456Z",
+            )
+
+        @add_client_method
+        def delete_cached_content(
+            request: glm.DeleteCachedContentRequest,
+            **kwargs,
+        ) -> None:
+            self.observed_requests.append(request)
+
+    def test_create_cached_content(self):
+
+        def add(a: int, b: int) -> int:
+            return a + b
+
+        cc = caching.CachedContent.create(
+            name="test-cached-content",
+            model="models/gemini-1.0-pro-001",
+            contents=["Add 5 and 6"],
+            tools=[add],
+            tool_config={"function_calling_config": "ANY"},
+            system_instruction="Always add 10 to the result.",
+            ttl=datetime.timedelta(minutes=30),
+        )
+        self.assertIsInstance(self.observed_requests[-1], glm.CreateCachedContentRequest)
+        self.assertIsInstance(cc, caching_types.CachedContent)
+        self.assertEqual(cc.name, "cachedContent/test-cached-content")
+        self.assertEqual(cc.model, "models/gemini-1.0-pro-001")
+
+    @parameterized.named_parameters(
+        [
+            dict(
+                testcase_name="ttl-is-int-seconds",
+                ttl=7200,
+            ),
+            dict(
+                testcase_name="ttl-is-timedelta",
+                ttl=datetime.timedelta(hours=2),
+            ),
+            dict(
+                testcase_name="ttl-is-dict",
+                ttl={"seconds": 7200},
+            ),
+            dict(
+                testcase_name="ttl-is-none-default-to-1-hr",
+                ttl=None,
+            ),
+        ]
+    )
+    def test_expiration_types_for_create_cached_content(self, ttl):
+        cc = caching.CachedContent.create(
+            name="test-cached-content",
+            model="models/gemini-1.0-pro-001",
+            contents=["cache this please for 2 hours"],
+            ttl=ttl,
+        )
+        self.assertIsInstance(self.observed_requests[-1], glm.CreateCachedContentRequest)
+        self.assertIsInstance(cc, caching_types.CachedContent)
+
+    def test_get_cached_content(self):
+        cc = caching.get_cached_content(name="cachedContent/test-cached-content")
+        self.assertIsInstance(self.observed_requests[-1], glm.GetCachedContentRequest)
+        self.assertIsInstance(cc, caching_types.CachedContent)
+        self.assertEqual(cc.name, "cachedContent/test-cached-content")
+        self.assertEqual(cc.model, "models/gemini-1.0-pro-001")
+
+    def test_list_cached_contents(self):
+        ccs = list(caching.list_cached_contents(page_size=2))
+        self.assertIsInstance(self.observed_requests[-1], glm.ListCachedContentsRequest)
+        self.assertLen(ccs, 2)
+        self.assertIsInstance(ccs[0], caching_types.CachedContent)
+        self.assertIsInstance(ccs[1], caching_types.CachedContent)
+
+    def test_update_cached_content_invalid_update_paths(self):
+        update_masks = dict(
+            name="change",
+            model="models/gemini-1.5-pro-001",
+            system_instruction="Always add 10 to the result.",
+            contents=["add this Content"],
+        )
+
+        cc = caching.get_cached_content(name="cachedContent/test-cached-content")
+        with self.assertRaises(ValueError):
+            cc.update(updates=update_masks)
+
+    def test_update_cached_content_valid_update_paths(self):
+        update_masks = dict(
+            ttl=datetime.timedelta(hours=2),
+        )
+
+        cc = caching.get_cached_content(name="cachedContent/test-cached-content")
+        cc = cc.update(updates=update_masks)
+        self.assertIsInstance(self.observed_requests[-1], glm.UpdateCachedContentRequest)
+        self.assertIsInstance(cc, caching_types.CachedContent)
+
+    def test_delete_cached_content(self):
+        cc = caching.get_cached_content(name="cachedContent/test-cached-content")
+        cc.delete()
+        self.assertIsInstance(self.observed_requests[-1], glm.DeleteCachedContentRequest)
+
+        cc = caching.delete_cached_content(name="cachedContent/test-cached-content")
+        self.assertIsInstance(self.observed_requests[-1], glm.DeleteCachedContentRequest)
+
+    def test_auto_delete_cached_content_with_context_manager(self):
+        with caching.CachedContent.create(
+            name="test-cached-content",
+            model="models/gemini-1.0-pro-001",
+            contents=["Add 5 and 6"],
+            system_instruction="Always add 10 to the result.",
+            ttl=datetime.timedelta(minutes=30),
+        ) as cc:
+            ...  # some logic
+
+        self.assertIsInstance(self.observed_requests[-1], glm.DeleteCachedContentRequest)
+
+
+if __name__ == "__main__":
+    absltest.main()

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -49,7 +49,7 @@ class UnitTests(parameterized.TestCase):
         ) -> glm.CachedContent:
             self.observed_requests.append(request)
             return glm.CachedContent(
-                name="cachedContent/test-cached-content",
+                name="cachedContents/test-cached-content",
                 model="models/gemini-1.0-pro-001",
                 create_time="2000-01-01T01:01:01.123456Z",
                 update_time="2000-01-01T01:01:01.123456Z",
@@ -63,7 +63,7 @@ class UnitTests(parameterized.TestCase):
         ) -> glm.CachedContent:
             self.observed_requests.append(request)
             return glm.CachedContent(
-                name="cachedContent/test-cached-content",
+                name="cachedContents/test-cached-content",
                 model="models/gemini-1.0-pro-001",
                 create_time="2000-01-01T01:01:01.123456Z",
                 update_time="2000-01-01T01:01:01.123456Z",
@@ -78,14 +78,14 @@ class UnitTests(parameterized.TestCase):
             self.observed_requests.append(request)
             return [
                 glm.CachedContent(
-                    name="cachedContent/test-cached-content-1",
+                    name="cachedContents/test-cached-content-1",
                     model="models/gemini-1.0-pro-001",
                     create_time="2000-01-01T01:01:01.123456Z",
                     update_time="2000-01-01T01:01:01.123456Z",
                     expire_time="2000-01-01T01:01:01.123456Z",
                 ),
                 glm.CachedContent(
-                    name="cachedContent/test-cached-content-2",
+                    name="cachedContents/test-cached-content-2",
                     model="models/gemini-1.0-pro-001",
                     create_time="2000-01-01T01:01:01.123456Z",
                     update_time="2000-01-01T01:01:01.123456Z",
@@ -100,7 +100,7 @@ class UnitTests(parameterized.TestCase):
         ) -> glm.CachedContent:
             self.observed_requests.append(request)
             return glm.CachedContent(
-                name="cachedContent/test-cached-content",
+                name="cachedContents/test-cached-content",
                 model="models/gemini-1.0-pro-001",
                 create_time="2000-01-01T01:01:01.123456Z",
                 update_time="2000-01-01T01:01:01.123456Z",
@@ -130,7 +130,7 @@ class UnitTests(parameterized.TestCase):
         )
         self.assertIsInstance(self.observed_requests[-1], glm.CreateCachedContentRequest)
         self.assertIsInstance(cc, caching.CachedContent)
-        self.assertEqual(cc.name, "cachedContent/test-cached-content")
+        self.assertEqual(cc.name, "cachedContents/test-cached-content")
         self.assertEqual(cc.model, "models/gemini-1.0-pro-001")
 
     @parameterized.named_parameters(
@@ -191,10 +191,10 @@ class UnitTests(parameterized.TestCase):
             )
 
     def test_get_cached_content(self):
-        cc = caching.CachedContent.get(name="cachedContent/test-cached-content")
+        cc = caching.CachedContent.get(name="cachedContents/test-cached-content")
         self.assertIsInstance(self.observed_requests[-1], glm.GetCachedContentRequest)
         self.assertIsInstance(cc, caching.CachedContent)
-        self.assertEqual(cc.name, "cachedContent/test-cached-content")
+        self.assertEqual(cc.name, "cachedContents/test-cached-content")
         self.assertEqual(cc.model, "models/gemini-1.0-pro-001")
 
     def test_list_cached_contents(self):
@@ -212,7 +212,7 @@ class UnitTests(parameterized.TestCase):
             contents=["add this Content"],
         )
 
-        cc = caching.CachedContent.get(name="cachedContent/test-cached-content")
+        cc = caching.CachedContent.get(name="cachedContents/test-cached-content")
         with self.assertRaises(ValueError):
             cc.update(updates=update_masks)
 
@@ -221,17 +221,17 @@ class UnitTests(parameterized.TestCase):
             ttl=datetime.timedelta(hours=2),
         )
 
-        cc = caching.CachedContent.get(name="cachedContent/test-cached-content")
+        cc = caching.CachedContent.get(name="cachedContents/test-cached-content")
         cc = cc.update(updates=update_masks)
         self.assertIsInstance(self.observed_requests[-1], glm.UpdateCachedContentRequest)
         self.assertIsInstance(cc, caching.CachedContent)
 
     def test_delete_cached_content(self):
-        cc = caching.CachedContent.get(name="cachedContent/test-cached-content")
+        cc = caching.CachedContent.get(name="cachedContents/test-cached-content")
         cc.delete()
         self.assertIsInstance(self.observed_requests[-1], glm.DeleteCachedContentRequest)
 
-        cc = caching.CachedContent.get(name="cachedContent/test-cached-content")
+        cc = caching.CachedContent.get(name="cachedContents/test-cached-content")
         cc.delete()
         self.assertIsInstance(self.observed_requests[-1], glm.DeleteCachedContentRequest)
 

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -163,6 +163,33 @@ class UnitTests(parameterized.TestCase):
         self.assertIsInstance(self.observed_requests[-1], glm.CreateCachedContentRequest)
         self.assertIsInstance(cc, caching.CachedContent)
 
+    @parameterized.named_parameters(
+        [
+            dict(
+                testcase_name="upper_case",
+                name="Test-cached-content",
+            ),
+            dict(
+                testcase_name="special_characters_except_dot_and_hyphen",
+                name="test-cac*@/hed-conte#nt",
+            ),
+            dict(
+                testcase_name="empty_name",
+                name="",
+            ),
+            dict(
+                testcase_name="blank_spaces",
+                name="test cached content",
+            ),
+        ]
+    )
+    def test_create_cached_content_with_invalid_name_format(self, name):
+        with self.assertRaises(ValueError):
+            _ = caching.CachedContent.create(
+                name=name,
+                model="models/gemini-1.0-pro-001",
+            )
+
     def test_get_cached_content(self):
         cc = caching.CachedContent.get(name="cachedContent/test-cached-content")
         self.assertIsInstance(self.observed_requests[-1], glm.GetCachedContentRequest)

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -204,7 +204,8 @@ class UnitTests(parameterized.TestCase):
         cc.delete()
         self.assertIsInstance(self.observed_requests[-1], glm.DeleteCachedContentRequest)
 
-        cc = caching.delete_cached_content(name="cachedContent/test-cached-content")
+        cc = caching.CachedContent.get(name="cachedContent/test-cached-content")
+        cc.delete()
         self.assertIsInstance(self.observed_requests[-1], glm.DeleteCachedContentRequest)
 
     def test_auto_delete_cached_content_with_context_manager(self):

--- a/tests/test_generative_models.py
+++ b/tests/test_generative_models.py
@@ -355,8 +355,8 @@ class CUJTests(parameterized.TestCase):
         self.assertEqual(cc_name, "cachedContents/test-cached-content")
         self.assertEqual(model_name, "models/gemini-1.0-pro-001")
         self.assertEqual(
-            model.cached_content, "cachedContents/test-cached-content"
-        )  # pytype: disable=attribute-error
+            model.cached_content, "cachedContents/test-cached-content"  # pytype: disable=attribute-error
+        )
 
     def test_content_generation_with_model_having_context(self):
         self.responses["generate_content"] = [simple_response("world!")]
@@ -367,8 +367,8 @@ class CUJTests(parameterized.TestCase):
 
         self.assertEqual(response.text, "world!")
         self.assertEqual(
-            model.cached_content, "cachedContents/test-cached-content"
-        )  # pytype: disable=attribute-error
+            model.cached_content, "cachedContents/test-cached-content"  # pytype: disable=attribute-error
+        )
 
     def test_fail_content_generation_with_model_having_context(self):
         model = generative_models.GenerativeModel.from_cached_content(

--- a/tests/test_generative_models.py
+++ b/tests/test_generative_models.py
@@ -355,7 +355,8 @@ class CUJTests(parameterized.TestCase):
         self.assertEqual(cc_name, "cachedContents/test-cached-content")
         self.assertEqual(model_name, "models/gemini-1.0-pro-001")
         self.assertEqual(
-            model.cached_content, "cachedContents/test-cached-content"  # pytype: disable=attribute-error
+            model.cached_content,  # pytype: disable=attribute-error
+            "cachedContents/test-cached-content",
         )
 
     def test_content_generation_with_model_having_context(self):
@@ -367,7 +368,8 @@ class CUJTests(parameterized.TestCase):
 
         self.assertEqual(response.text, "world!")
         self.assertEqual(
-            model.cached_content, "cachedContents/test-cached-content"  # pytype: disable=attribute-error
+            model.cached_content,  # pytype: disable=attribute-error
+            "cachedContents/test-cached-content",
         )
 
     def test_fail_content_generation_with_model_having_context(self):

--- a/tests/test_generative_models.py
+++ b/tests/test_generative_models.py
@@ -10,9 +10,9 @@ from absl.testing import parameterized
 import google.ai.generativelanguage as glm
 from google.generativeai import client as client_lib
 from google.generativeai import generative_models
+from google.generativeai import caching
 from google.generativeai.types import content_types
 from google.generativeai.types import generation_types
-from google.generativeai.types import caching_types
 from google.generativeai.types import helper_types
 
 import PIL.Image
@@ -337,7 +337,7 @@ class CUJTests(parameterized.TestCase):
             dict(testcase_name="test_cached_content_as_id", cached_content="test-cached-content"),
             dict(
                 testcase_name="test_cached_content_as_CachedContent_object",
-                cached_content=caching_types.CachedContent(
+                cached_content=caching.CachedContent(
                     name="cachedContent/test-cached-content",
                     model="models/gemini-1.0-pro-001",
                     create_time="2000-01-01T01:01:01.123456Z",

--- a/tests/test_generative_models.py
+++ b/tests/test_generative_models.py
@@ -1213,6 +1213,7 @@ class CUJTests(parameterized.TestCase):
                     safety_settings={},
                     tools=None,
                     system_instruction=None,
+                    cached_content=None
                 ),
                 history=[glm.Content({'parts': [{'text': 'I really like fantasy books.'}], 'role': 'user'}), glm.Content({'parts': [{'text': 'first'}], 'role': 'model'}), glm.Content({'parts': [{'text': 'I also like this image.'}, {'inline_data': {'data': 'iVBORw0KGgoA...AAElFTkSuQmCC', 'mime_type': 'image/png'}}], 'role': 'user'}), glm.Content({'parts': [{'text': 'second'}], 'role': 'model'}), glm.Content({'parts': [{'text': 'What things do I like?.'}], 'role': 'user'}), glm.Content({'parts': [{'text': 'third'}], 'role': 'model'})]
             )"""
@@ -1241,6 +1242,7 @@ class CUJTests(parameterized.TestCase):
                     safety_settings={},
                     tools=None,
                     system_instruction=None,
+                    cached_content=None
                 ),
                 history=[glm.Content({'parts': [{'text': 'I really like fantasy books.'}], 'role': 'user'}), <STREAMING IN PROGRESS>]
             )"""
@@ -1285,6 +1287,7 @@ class CUJTests(parameterized.TestCase):
                     safety_settings={},
                     tools=None,
                     system_instruction=None,
+                    cached_content=None
                 ),
                 history=[glm.Content({'parts': [{'text': 'I really like fantasy books.'}], 'role': 'user'}), <STREAMING ERROR>]
             )"""
@@ -1295,6 +1298,14 @@ class CUJTests(parameterized.TestCase):
         model = generative_models.GenerativeModel("gemini-pro", system_instruction="Be excellent.")
         result = repr(model)
         self.assertIn("system_instruction='Be excellent.'", result)
+
+    def test_repr_for_model_created_from_cahced_content(self):
+        model = generative_models.GenerativeModel.from_cached_content(
+            cached_content="test-cached-content"
+        )
+        result = repr(model)
+        self.assertIn("cached_content=cachedContent/test-cached-content", result)
+        self.assertIn("model_name='models/gemini-1.0-pro-001'", result)
 
     def test_count_tokens_called_with_request_options(self):
         self.responses["count_tokens"].append(glm.CountTokensResponse())

--- a/tests/test_generative_models.py
+++ b/tests/test_generative_models.py
@@ -80,11 +80,11 @@ class MockGenerativeServiceClient:
 
     def get_cached_content(
         self,
-        request: glm.GetCachedContentRequest,
+        request: protos.GetCachedContentRequest,
         **kwargs,
-    ) -> glm.CachedContent:
+    ) -> protos.CachedContent:
         self.observed_requests.append(request)
-        return glm.CachedContent(
+        return protos.CachedContent(
             name="cachedContents/test-cached-content",
             model="models/gemini-1.0-pro-001",
             create_time="2000-01-01T01:01:01.123456Z",

--- a/tests/test_generative_models.py
+++ b/tests/test_generative_models.py
@@ -1,6 +1,7 @@
 import collections
 from collections.abc import Iterable
 import copy
+import datetime
 import pathlib
 from typing import Any
 import textwrap
@@ -111,7 +112,6 @@ class CUJTests(parameterized.TestCase):
         self.client = MockGenerativeServiceClient(self)
         client_lib._client_manager.clients["generative"] = self.client
         client_lib._client_manager.clients["cache"] = self.client
-
 
     def test_hello(self):
         # Generate text from text prompt
@@ -338,7 +338,13 @@ class CUJTests(parameterized.TestCase):
             dict(testcase_name="test_cached_content_as_id", cached_content="test-cached-content"),
             dict(
                 testcase_name="test_cached_content_as_CachedContent_object",
-                cached_content=caching.CachedContent.get(name="cachedContents/test-cached-content"),
+                cached_content=caching.CachedContent(
+                    name="cachedContents/test-cached-content",
+                    model="models/gemini-1.0-pro-001",
+                    create_time=datetime.datetime.now(),
+                    update_time=datetime.datetime.now(),
+                    expire_time=datetime.datetime.now(),
+                ),
             ),
         ],
     )
@@ -1289,7 +1295,7 @@ class CUJTests(parameterized.TestCase):
             cached_content="test-cached-content"
         )
         result = repr(model)
-        self.assertIn("cached_content=cachedContent/test-cached-content", result)
+        self.assertIn("cached_content=cachedContents/test-cached-content", result)
         self.assertIn("model_name='models/gemini-1.0-pro-001'", result)
 
     def test_count_tokens_called_with_request_options(self):

--- a/tests/test_generative_models.py
+++ b/tests/test_generative_models.py
@@ -76,6 +76,20 @@ class MockGenerativeServiceClient:
         self.observed_kwargs.append(kwargs)
         response = self.responses["count_tokens"].pop(0)
         return response
+    
+    def get_cached_content(
+        self,
+        request: glm.GetCachedContentRequest,
+        **kwargs,
+    ) -> glm.CachedContent:
+        self.observed_requests.append(request)
+        return glm.CachedContent(
+            name="cachedContent/test-cached-content",
+            model="models/gemini-1.0-pro-001",
+            create_time="2000-01-01T01:01:01.123456Z",
+            update_time="2000-01-01T01:01:01.123456Z",
+            expire_time="2000-01-01T01:01:01.123456Z",
+        )
 
 
 class CUJTests(parameterized.TestCase):
@@ -98,19 +112,19 @@ class CUJTests(parameterized.TestCase):
         client_lib._client_manager.clients["generative"] = self.client
         client_lib._client_manager.clients["cache"] = self.client
 
-        @add_client_method
-        def get_cached_content(
-            request: glm.GetCachedContentRequest,
-            **kwargs,
-        ) -> glm.CachedContent:
-            self.observed_requests.append(request)
-            return glm.CachedContent(
-                name="cachedContent/test-cached-content",
-                model="models/gemini-1.0-pro-001",
-                create_time="2000-01-01T01:01:01.123456Z",
-                update_time="2000-01-01T01:01:01.123456Z",
-                expire_time="2000-01-01T01:01:01.123456Z",
-            )
+        # @add_client_method
+        # def get_cached_content(
+        #     request: glm.GetCachedContentRequest,
+        #     **kwargs,
+        # ) -> glm.CachedContent:
+        #     self.observed_requests.append(request)
+        #     return glm.CachedContent(
+        #         name="cachedContent/test-cached-content",
+        #         model="models/gemini-1.0-pro-001",
+        #         create_time="2000-01-01T01:01:01.123456Z",
+        #         update_time="2000-01-01T01:01:01.123456Z",
+        #         expire_time="2000-01-01T01:01:01.123456Z",
+        #     )
 
     def test_hello(self):
         # Generate text from text prompt

--- a/tests/test_generative_models.py
+++ b/tests/test_generative_models.py
@@ -353,6 +353,7 @@ class CUJTests(parameterized.TestCase):
         model_name = model.model_name
         self.assertEqual(cc_name, "cachedContent/test-cached-content")
         self.assertEqual(model_name, "models/gemini-1.0-pro-001")
+        self.assertEqual(model.cached_content, "cachedContent/test-cached-content")
 
     def test_content_generation_with_model_having_context(self):
         self.responses["generate_content"] = [simple_response("world!")]
@@ -362,6 +363,7 @@ class CUJTests(parameterized.TestCase):
         response = model.generate_content("Hello")
 
         self.assertEqual(response.text, "world!")
+        self.assertEqual(model.cached_content, "cachedContent/test-cached-content")
 
     def test_fail_content_generation_with_model_having_context(self):
         model = generative_models.GenerativeModel.from_cached_content(

--- a/tests/test_generative_models.py
+++ b/tests/test_generative_models.py
@@ -76,7 +76,7 @@ class MockGenerativeServiceClient:
         self.observed_kwargs.append(kwargs)
         response = self.responses["count_tokens"].pop(0)
         return response
-    
+
     def get_cached_content(
         self,
         request: glm.GetCachedContentRequest,


### PR DESCRIPTION
Change-Id: I694545243efda467d6fd599beded0dc6679b727d

===DO NOT SUBMIT===

*Inital prototype for explicit caching

*Add basic **CURD** support for caching

*Remove `INPUT_ONLY` marked fields from `CachedContent` dataclass

*Rename files `cached_content*` -> `caching*`

*Update `create` method for explicit instantination of 'CachedContent'

*Add a factory method to instatinate model with `CachedContent` as its context

*blacken

*Add tests

*Rename `get_cached_content` -> `get`

*Stroke out functional approach for `CachedContent` **CURD** ops

*Validate `name` checks for `CachedContent` creation

*Update repr for `GenerativeModel` to include information about the model's context

*Update docstrings

*Improve tests

