### PR TITLE
Remove duplicate test

### DIFF
--- a/tests/test_async_code_match.py
+++ b/tests/test_async_code_match.py
@@ -87,7 +87,7 @@ class CodeMatch(absltest.TestCase):
             for node in ast.walk(source_nodes):
                 if isinstance(
                     node, (ast.FunctionDef, ast.AsyncFunctionDef)
-                ) and not node.name.startswith("_"):
+                ) and not node.name.startswith("__"):
                     name = node.name[:-6] if node.name.endswith("_async") else node.name
                     if name in EXEMPT_FUNCTIONS or self._inspect_decorator_exemption(node, fpath):
                         continue

--- a/tests/test_generative_models.py
+++ b/tests/test_generative_models.py
@@ -844,56 +844,6 @@ class CUJTests(parameterized.TestCase):
         response = model.count_tokens(**kwargs)
         self.assertEqual(type(response).to_dict(response), {"total_tokens": 7})
 
-    @parameterized.named_parameters(
-        [
-            "GenerateContentResponse",
-            generation_types.GenerateContentResponse,
-            generation_types.AsyncGenerateContentResponse,
-        ],
-        [
-            "GenerativeModel.generate_response",
-            generative_models.GenerativeModel.generate_content,
-            generative_models.GenerativeModel.generate_content_async,
-        ],
-        [
-            "GenerativeModel.count_tokens",
-            generative_models.GenerativeModel.count_tokens,
-            generative_models.GenerativeModel.count_tokens_async,
-        ],
-        [
-            "ChatSession.send_message",
-            generative_models.ChatSession.send_message,
-            generative_models.ChatSession.send_message_async,
-        ],
-        [
-            "ChatSession._handle_afc",
-            generative_models.ChatSession._handle_afc,
-            generative_models.ChatSession._handle_afc_async,
-        ],
-    )
-    def test_async_code_match(self, obj, aobj):
-        import inspect
-        import re
-
-        source = inspect.getsource(obj)
-        asource = inspect.getsource(aobj)
-
-        source = re.sub('""".*"""', "", source, flags=re.DOTALL)
-        asource = re.sub('""".*"""', "", asource, flags=re.DOTALL)
-
-        asource = (
-            asource.replace("anext", "next")
-            .replace("aiter", "iter")
-            .replace("_async", "")
-            .replace("async ", "")
-            .replace("await ", "")
-            .replace("Async", "")
-            .replace("ASYNC_", "")
-        )
-
-        asource = re.sub(" *?# type: ignore", "", asource)
-        self.assertEqual(source, asource, f"error in {obj=}")
-
     def test_repr_for_unary_non_streamed_response(self):
         model = generative_models.GenerativeModel(model_name="gemini-pro")
         self.responses["generate_content"].append(simple_response("world!"))


### PR DESCRIPTION
- Allow async-code-match to consider methods starting with `_` (this is done to handle methods like `_handle_afc` and its async counterpart)
- Remove duplicate tests