### PR TITLE
fix genai.GenerativeModel argument name in example

### DIFF
--- a/google/generativeai/__init__.py
+++ b/google/generativeai/__init__.py
@@ -30,7 +30,7 @@ import os
 
 genai.configure(api_key=os.environ['API_KEY'])
 
-model = genai.GenerativeModel(name='gemini-1.5-flash')
+model = genai.GenerativeModel(model_name='gemini-1.5-flash')
 response = model.generate_content('Teach me about how an LLM works')
 
 print(response.text)


### PR DESCRIPTION
## Description of the change

Fix wrong argument in `__init__.py` which shows up on the [website](https://ai.google.dev/api/python/google/generativeai).

## Motivation

The example on the documentation is not working.

## Type of change

Bug fix

## Checklist
- [ x ] I have performed a self-review of my code.
- [ x ] I have added detailed comments to my code where applicable.
- [ x ] I have verified that my change does not break existing code.
- [ x ] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [ x ] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [ x ] I have read through the [Contributing Guide](https://github.com/google/generative-ai-python/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).