### PR TITLE
Using the `GEMINI_API_KEY` by default instead of the `GOOGLE_API_KEY` one

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Import the SDK and configure your API key.
 import google.generativeai as genai
 import os
 
-genai.configure(api_key=os.environ["GOOGLE_API_KEY"])
+genai.configure(api_key=os.environ["GEMINI_API_KEY"])
 ```
 
 Create a model and run a prompt.

--- a/google/generativeai/client.py
+++ b/google/generativeai/client.py
@@ -163,9 +163,9 @@ class _ClientManager:
                 # If no key is provided explicitly, attempt to load one from the
                 # environment.
                 api_key = os.getenv("GEMINI_API_KEY")
-            
+
             if api_key is None:
-                # If the GEMINI_API_KEY doesn't exist, attempt to load the 
+                # If the GEMINI_API_KEY doesn't exist, attempt to load the
                 # GOOGLE_API_KEY from the environment.
                 api_key = os.getenv("GOOGLE_API_KEY")
 

--- a/google/generativeai/client.py
+++ b/google/generativeai/client.py
@@ -164,7 +164,7 @@ class _ClientManager:
                 # environment.
                 api_key = os.getenv("GEMINI_API_KEY")
 
-            elif api_key is None:
+            if api_key is None:
                 # If the GEMINI_API_KEY doesn't exist, attempt to load the
                 # GOOGLE_API_KEY from the environment.
                 api_key = os.getenv("GOOGLE_API_KEY")

--- a/google/generativeai/client.py
+++ b/google/generativeai/client.py
@@ -164,7 +164,7 @@ class _ClientManager:
                 # environment.
                 api_key = os.getenv("GEMINI_API_KEY")
 
-            if api_key is None:
+            elif api_key is None:
                 # If the GEMINI_API_KEY doesn't exist, attempt to load the
                 # GOOGLE_API_KEY from the environment.
                 api_key = os.getenv("GOOGLE_API_KEY")

--- a/google/generativeai/client.py
+++ b/google/generativeai/client.py
@@ -131,7 +131,8 @@ class _ClientManager:
         """Initializes default client configurations using specified parameters or environment variables.
 
         If no API key has been provided (either directly, or on `client_options`) and the
-        `GOOGLE_API_KEY` environment variable is set, it will be used as the API key.
+        `GEMINI_API_KEY` environment variable is set, it will be used as the API key. If not,
+        if the `GOOGLE_API_KEY` environement variable is set, it will be used as the API key.
 
         Note: Not all arguments are detailed below. Refer to the `*ServiceClient` classes in
         `google.ai.generativelanguage` for details on the other arguments.
@@ -140,8 +141,8 @@ class _ClientManager:
             transport: A string, one of: [`rest`, `grpc`, `grpc_asyncio`].
             api_key: The API-Key to use when creating the default clients (each service uses
                 a separate client). This is a shortcut for `client_options={"api_key": api_key}`.
-                If omitted, and the `GOOGLE_API_KEY` environment variable is set, it will be
-                used.
+                If omitted, and the `GEMINI_API_KEY` or the `GOOGLE_API_KEY` environment variable
+                are set, they will be used in this order of priority.
             default_metadata: Default (key, value) metadata pairs to send with every request.
                 when using `transport="rest"` these are sent as HTTP headers.
         """
@@ -161,6 +162,11 @@ class _ClientManager:
             if api_key is None:
                 # If no key is provided explicitly, attempt to load one from the
                 # environment.
+                api_key = os.getenv("GEMINI_API_KEY")
+            
+            if api_key is None:
+                # If the GEMINI_API_KEY doesn't exist, attempt to load the 
+                # GOOGLE_API_KEY from the environment.
                 api_key = os.getenv("GOOGLE_API_KEY")
 
             client_options.api_key = api_key

--- a/google/generativeai/types/discuss_types.py
+++ b/google/generativeai/types/discuss_types.py
@@ -121,7 +121,7 @@ class ChatResponse(abc.ABC):
     ```
     import google.generativeai as genai
 
-    genai.configure(api_key=os.environ['GOOGLE_API_KEY'])
+    genai.configure(api_key=os.environ['GEMINI_API_KEY'])
 
     response = genai.chat(messages=["Hello."])
     print(response.last) #  'Hello! What can I help you with?'


### PR DESCRIPTION
## Description of the change
Instead of using the `GOOGLE_API_KEY` by default, we're checking for the `GEMINI_API_KEY` ones first since its naming is less misleading. The `GOOGLE_API_KEY` is still kept for consistency.

## Motivation
The Google API key can be misleading since it's not really an overall key for all of Google API and only for the Gemini ones.

## Type of change
Choose one: Feature request

## Checklist
- [X] I have performed a self-review of my code.
- [X] I have added detailed comments to my code where applicable.
- [X] I have verified that my change does not break existing code.
- [X] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [X] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [X] I have read through the [Contributing Guide](https://github.com/google/generative-ai-python/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
