### PR TITLE
Add PngImagePlugin to imports.

### DIFF
--- a/google/generativeai/types/content_types.py
+++ b/google/generativeai/types/content_types.py
@@ -30,6 +30,7 @@ from google.generativeai import protos
 
 if typing.TYPE_CHECKING:
     import PIL.Image
+    import PIL.PngImagePlugin
     import IPython.display
 
     IMAGE_TYPES = (PIL.Image.Image, IPython.display.Image)
@@ -37,6 +38,7 @@ else:
     IMAGE_TYPES = ()
     try:
         import PIL.Image
+        import PIL.PngImagePlugin
 
         IMAGE_TYPES = IMAGE_TYPES + (PIL.Image.Image,)
     except ImportError:


### PR DESCRIPTION
## Description of the change
Imports `PIL.PngImagePlugin` that was assumed to be loaded as part of PIL but isn't guaranteed to be loaded before this code is called. 

## Motivation
Adds an import statement to avoid an error when PIL is partially loaded resulting in the following error: `AttributeError: module 'PIL' has no attribute 'PngImagePlugin'`. This was already mentioned but not resolved in #178. 

## Type of change
Bug Fix

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have added detailed comments to my code where applicable.
- [x] I have verified that my change does not break existing code.
- [x] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [x] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [x] I have read through the [Contributing Guide](https://github.com/google/generative-ai-python/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).

Fixes: #178