### PR TITLE
Fix Model dataclass

### DIFF
--- a/google/generativeai/types/model_types.py
+++ b/google/generativeai/types/model_types.py
@@ -117,6 +117,7 @@ class Model:
     output_token_limit: int
     supported_generation_methods: list[str]
     temperature: float | None = None
+    max_temperature: float | None = None
     top_p: float | None = None
     top_k: int | None = None
 


### PR DESCRIPTION
Dataclass Model misses max_temperature field which brakes list_models()

## Description of the change
Fix Model dataclass with adding max_temperature field

## Motivation
list_models() doesn't work without max_temperature

## Type of change
Bug fix

## Checklist
- [+ ] I have performed a self-review of my code.
- [ +] I have added detailed comments to my code where applicable.
- [ +] I have verified that my change does not break existing code.
- [ +] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [ +] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [ +] I have read through the [Contributing Guide](https://github.com/google/generative-ai-python/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
