### PR TITLE
fix: correct the Part argument is not iterable error

### DIFF
--- a/google/generativeai/types/generation_types.py
+++ b/google/generativeai/types/generation_types.py
@@ -440,10 +440,10 @@ class BaseGenerateContentResponse:
 
         texts = []
         for part in parts:
-            if "text" in dir(part):
+            if hasattr(part, "text"):
                 texts.append(part.text)
                 continue
-            if "executable_code" in dir(part):
+            if hasattr(part, "executable_code"):
                 language = part.executable_code.language.name.lower()
                 if language == "language_unspecified":
                     language = ""
@@ -451,7 +451,7 @@ class BaseGenerateContentResponse:
                     language = f" {language}"
                 texts.extend([f"```{language}", part.executable_code.code.lstrip("\n"), "```"])
                 continue
-            if "code_execution_result" in dir(part):
+            if hasattr(part, "code_execution_result"):
                 outcome_result = part.code_execution_result.outcome.name.lower().replace(
                     "outcome_", ""
                 )

--- a/google/generativeai/types/generation_types.py
+++ b/google/generativeai/types/generation_types.py
@@ -440,10 +440,10 @@ class BaseGenerateContentResponse:
 
         texts = []
         for part in parts:
-            if "text" in part:
+            if "text" in dir(part):
                 texts.append(part.text)
                 continue
-            if "executable_code" in part:
+            if "executable_code" in dir(part):
                 language = part.executable_code.language.name.lower()
                 if language == "language_unspecified":
                     language = ""
@@ -451,7 +451,7 @@ class BaseGenerateContentResponse:
                     language = f" {language}"
                 texts.extend([f"```{language}", part.executable_code.code.lstrip("\n"), "```"])
                 continue
-            if "code_execution_result" in part:
+            if "code_execution_result" in dir(part):
                 outcome_result = part.code_execution_result.outcome.name.lower().replace(
                     "outcome_", ""
                 )


### PR DESCRIPTION
## Description of the change
<!--- Describe your changes in detail. -->
I have changed the ``generation_types.py`` file. The changed line at [443, 446, 454]. Turn the ``part`` into ``dir(part)``

## Motivation
<!--- Why is this change required? What problem does it solve? Please include the corresponding issue number/link if applicable. -->
When using this library like:

```python
response = genai.GenerativeModel('gemini-pro').generate_content("test",)
print(response.text)
```

the following error has occur:

```python
File google\generativeai\types\generation_types.py:443, in BaseGenerateContentResponse.text(self)
    [441](google/generativeai/types/generation_types.py:441) texts = []
    [442](google/generativeai/types/generation_types.py:442) for part in parts:
--> [443](google/generativeai/types/generation_types.py:443)     if "text" in part:
    [444](google/generativeai/types/generation_types.py:444)         texts.append(part.text)
    [445](google/generativeai/types/generation_types.py:445)         continue

TypeError: argument of type 'Part' is not iterable
```

## Type of change
Bug fix

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have verified that my change does not break existing code.
- [x] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [x] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
