### PR TITLE
Fix the missing closing backticks in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,10 +93,11 @@ pytest
 
 Or to debug, use:
 
-```commandline
+```
 pip install nose2
 
 nose2 --debugger
+```
 
 ### Type checking 
 
@@ -123,7 +124,6 @@ black .
 ```
 python docs/build_docs.py
 ```
-
 
 [setup]: https://cloud.google.com/nodejs/docs/setup
 [projects]: https://console.cloud.google.com/project


### PR DESCRIPTION
The rendering is broken due to the missing closing backticks.

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->
- [ ] I have performed a self-review of my code.
- [ ] I have added detailed comments to my code where applicable.
- [ ] I have verified that my change does not break existing code.
- [ ] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [ ] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [ ] I have read through the [Contributing Guide](https://github.com/google/generative-ai-python/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
