### PR TITLE
Avoid making recommendations about regions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The Google AI Python SDK is the easiest way for Python developers to build with 
 ## Get started with the Gemini API
 1. Go to [Google AI Studio](https://aistudio.google.com/).
 2. Login with your Google account.
-3. [Create](https://aistudio.google.com/app/apikey) an API key. Note that in Europe the free tier is not available.
+3. [Create](https://aistudio.google.com/app/apikey) an API key.
 4. Try a Python SDK [quickstart](https://github.com/google-gemini/gemini-api-cookbook/blob/main/quickstarts/Prompting.ipynb) in the [Gemini API Cookbook](https://github.com/google-gemini/gemini-api-cookbook/).
 5. For detailed instructions, try the 
 [Python SDK tutorial](https://ai.google.dev/tutorials/python_quickstart) on [ai.google.dev](https://ai.google.dev).


### PR DESCRIPTION
The region coverage is subject to change as we are rolling out AI Studio to more regions like the UK and EU. Users will be pointed to https://ai.google.dev/gemini-api/docs/available-regions if they are located in a region that is not yet supported.

We won't be able to maintain outdated documents on READMEs moving forward, so please either don't mention some of the operational details that are subject to change or provide a link to the official docs.
