### PR TITLE
Ensure tests are runnable when standalone

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -12,11 +12,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import pathlib
 import copy
 import collections
 from typing import Union
 
+from absl.testing import absltest
 from absl.testing import parameterized
 
 from google.generativeai import protos
@@ -81,3 +81,7 @@ class HelperTests(parameterized.TestCase):
 
         self.assertEqual(self.observed_timeout[0], expected_timeout)
         self.assertEqual(str(self.observed_retry[0]), str(expected_retry))
+
+
+if __name__ == "__main__":
+    absltest.main()

--- a/tests/test_protos.py
+++ b/tests/test_protos.py
@@ -15,6 +15,7 @@
 import pathlib
 import re
 
+from absl.testing import absltest
 from absl.testing import parameterized
 
 ROOT = pathlib.Path(__file__).parent.parent
@@ -32,3 +33,7 @@ class UnitTests(parameterized.TestCase):
                     match,
                     msg=f"Bad `glm.` usage, use `genai.protos` instead,\n   in {fpath}",
                 )
+
+
+if __name__ == "__main__":
+    absltest.main()

--- a/tests/test_responder.py
+++ b/tests/test_responder.py
@@ -19,8 +19,7 @@ from absl.testing import absltest
 from absl.testing import parameterized
 from google.generativeai import protos
 from google.generativeai import responder
-import IPython.display
-import PIL.Image
+
 
 HERE = pathlib.Path(__file__).parent
 TEST_PNG_PATH = HERE / "test_img.png"
@@ -250,3 +249,7 @@ class UnitTests(parameterized.TestCase):
         cfd = responder.FunctionDeclaration.from_function(fun)
         got = cfd.parameters.properties["a"]
         self.assertEqual(got, expected)
+
+
+if __name__ == "__main__":
+    absltest.main()


### PR DESCRIPTION
When we run tests internally that don't invoke the test class, they pass but don't run the tests.

Our GitHub environment tests them fine but this change ensures they run in both environments.

I also removed unused imports in these files.