### PR TITLE
fix: thread-safe discovery API setup (Issues#327)

### DIFF
--- a/google/generativeai/client.py
+++ b/google/generativeai/client.py
@@ -5,6 +5,7 @@ import contextlib
 import inspect
 import dataclasses
 import pathlib
+import threading
 from typing import Any, cast
 from collections.abc import Sequence
 import httplib2
@@ -64,6 +65,7 @@ def patch_colab_gce_credentials():
 class FileServiceClient(glm.FileServiceClient):
     def __init__(self, *args, **kwargs):
         self._discovery_api = None
+        self._local = threading.local()
         super().__init__(*args, **kwargs)
 
     def _setup_discovery_api(self, metadata: dict | Sequence[tuple[str, str]] = ()):
@@ -83,7 +85,7 @@ class FileServiceClient(glm.FileServiceClient):
         request.http.close()
 
         discovery_doc = content.decode("utf-8")
-        self._discovery_api = googleapiclient.discovery.build_from_document(
+        self._local.discovery_api = googleapiclient.discovery.build_from_document(
             discovery_doc, developerKey=api_key
         )
 
@@ -115,7 +117,7 @@ class FileServiceClient(glm.FileServiceClient):
                 filename=path, mimetype=mime_type, resumable=resumable
             )
 
-        request = self._discovery_api.media().upload(body={"file": file}, media_body=media)
+        request = self._local.discovery_api.media().upload(body={"file": file}, media_body=media)
         for key, value in metadata:
             request.headers[key] = value
         result = request.execute()


### PR DESCRIPTION
## Description of the change
Added threading support to `FileServiceClient` to make `discovery_api` thread-local.

## Motivation
Fixes a threading issue where multiple threads could simultaneously access `self._discovery_api`, leading to bugs. Making `discovery_api` thread-local gives each thread its own instance.

**Resolves:** [#327](https://github.com/google-gemini/generative-ai-python/issues/327)

## Type of change
Bug fix

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have added detailed comments to my code where applicable.
- [x] I have verified that my change does not break existing code.
- [x] My PR is based on the latest changes of the main branch.
- [x] I am familiar with the [Google Style Guide for Python](https://google.github.io/styleguide/).
- [x] I have read the [Contributing Guide](https://github.com/google/generative-ai-python/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
