### PR TITLE
Use double quotes for JSON object keys

### DIFF
--- a/samples/rest/code_execution.sh
+++ b/samples/rest/code_execution.sh
@@ -4,7 +4,7 @@ echo "[START code_execution_basic]"
 # [START code_execution_basic]
 curl "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=$GOOGLE_API_KEY" \
 -H 'Content-Type: application/json' \
--d ' {"tools": [{'code_execution': {}}],
+-d ' {"tools": [{"code_execution": {}}],
     "contents": {
       "parts": 
         {
@@ -18,7 +18,7 @@ echo "[START code_execution_chat]"
 # [START code_execution_chat]
 curl "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=$GOOGLE_API_KEY" \
 -H 'Content-Type: application/json' \
--d '{"tools": [{'code_execution': {}}],
+-d '{"tools": [{"code_execution": {}}],
     "contents": [
         {
             "role": "user",


### PR DESCRIPTION
## Description of the change

Use double-quoted string instead of single-quoted string in JSON.

## Motivation

The string 'code_execution' is unexpectedly single-quoted in a JSON string when it should be double-quoted. Apparently this still works for the API (as does not quoting the object key at all) but the Bash syntax highligher is confused and thinks that the 'code_execution' text is not part of the string.

> ![image](https://github.com/user-attachments/assets/96d4e803-bf59-4e02-968d-eb7222215396)

## Type of change
Choose one: Documentation

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->
- [x] I have performed a self-review of my code.
- [x] I have added detailed comments to my code where applicable.
- [x] I have verified that my change does not break existing code.
- [x] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [x] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [x] I have read through the [Contributing Guide](https://github.com/google/generative-ai-python/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
