### PR TITLE
Refactor embedding model name in call

### DIFF
--- a/google/generativeai/types/model_types.py
+++ b/google/generativeai/types/model_types.py
@@ -355,7 +355,10 @@ def make_model_name(name: AnyModelNameOptions):
     if isinstance(name, (Model, protos.Model, TunedModel, protos.TunedModel)):
         name = name.name  # pytype: disable=attribute-error
     elif isinstance(name, str):
-        name = name
+        if "/" not in name:
+            name = "models/" + name
+        else:
+            name = name
     else:
         raise TypeError(
             "Invalid input type. Expected one of the following types: `str`, `Model`, or `TunedModel`."


### PR DESCRIPTION
## Description of the change
Embedding model requires to mention as "models/<model_name>" but not other generative models which is simply "<model_name>"

## Motivation
It just for consistency of model usage. May fix #640.

## Type of change
Feature request

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->
- I have performed a self-review of my code.
- I have added detailed comments to my code where applicable.
- I have verified that my change does not break existing code.
- My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- I have read through the [Contributing Guide](https://github.com/google/generative-ai-python/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
