### PR TITLE
Update GenerationConfig.md to fix typo

### DIFF
--- a/docs/api/google/generativeai/protos/GenerationConfig.md
+++ b/docs/api/google/generativeai/protos/GenerationConfig.md
@@ -242,7 +242,7 @@ been seen in the respponse so far.
 A positive penalty will discourage the use of tokens that
 have already been used, proportional to the number of times
 the token has been used: The more a token is used, the more
-dificult it is for the model to use that token again
+difficult it is for the model to use that token again
 increasing the vocabulary of responses.
 
 Caution: A *negative* penalty will encourage the model to


### PR DESCRIPTION
Fixed typo in Frequency Penalty description by changing "dificult" to "difficult".

## Description of the change
Fixed an unfortunate misspelling of the word "difficult". The current documentation spells the word as "dificult" (one 'f') when the correct spelling is "difficult" (two 'f').

## Motivation
Implementing this change will improve the professionalism of the documentation and prevent readers from being caught off guard/distracted by the misspelling of a word.

## Type of change
Documentation

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->
- [ x] I have performed a self-review of my code.
- [ x] I have added detailed comments to my code where applicable.
- [ x] I have verified that my change does not break existing code.
- [ x] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [ x] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [ x] I have read through the [Contributing Guide](https://github.com/google/generative-ai-python/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
