### PR TITLE
Add support for per-request metadata/headers in GenerativeModel.gener…

### DIFF
--- a/google/generativeai/generative_models.py
+++ b/google/generativeai/generative_models.py
@@ -244,6 +244,7 @@ class GenerativeModel:
         tools: content_types.FunctionLibraryType | None = None,
         tool_config: content_types.ToolConfigType | None = None,
         request_options: helper_types.RequestOptionsType | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> generation_types.GenerateContentResponse:
         """A multipurpose function to generate responses from the model.
 
@@ -318,7 +319,22 @@ class GenerativeModel:
 
         if request_options is None:
             request_options = {}
+        else:
+            request_options = (
+                request_options.copy()
+                if isinstance(request_options, dict)
+                else vars(request_options).copy()
+            )
 
+        metadata = list(request_options.get("metadata", []))
+        if extra_headers:
+            metadata += list(extra_headers.items())
+
+        if metadata:
+            request_options["metadata"] = metadata
+        elif "metadata" in request_options:
+            del request_options["metadata"]
+ 
         try:
             if stream:
                 with generation_types.rewrite_stream_error():
@@ -351,6 +367,7 @@ class GenerativeModel:
         tools: content_types.FunctionLibraryType | None = None,
         tool_config: content_types.ToolConfigType | None = None,
         request_options: helper_types.RequestOptionsType | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> generation_types.AsyncGenerateContentResponse:
         """The async version of `GenerativeModel.generate_content`."""
         if not contents:
@@ -372,6 +389,21 @@ class GenerativeModel:
 
         if request_options is None:
             request_options = {}
+        else:
+            request_options = (
+                request_options.copy()
+                if isinstance(request_options, dict)
+                else vars(request_options).copy()
+            )
+
+        metadata = list(request_options.get("metadata", []))
+        if extra_headers:
+            metadata += list(extra_headers.items())
+
+        if metadata:
+            request_options["metadata"] = metadata
+        elif "metadata" in request_options:
+            del request_options["metadata"]
 
         try:
             if stream:

--- a/tests/test_generative_models_async.py
+++ b/tests/test_generative_models_async.py
@@ -91,6 +91,44 @@ class AsyncTests(parameterized.TestCase, unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(response.text, "world!")
 
+    async def test_generate_content_async_with_extra_headerss(self):
+        self.client.generate_content = unittest.mock.AsyncMock()
+        request = unittest.mock.ANY
+        extra_headers = {
+            "Helicone-User-Id": "test-user-123",
+            "Custom-Header": "test-value"
+        }
+
+        model = generative_models.GenerativeModel(model_name="gemini-1.5-flash")
+        await model.generate_content_async("Hello", extra_headers=extra_headers)
+
+        expected_request_options = {"metadata": list(extra_headers.items())}
+
+        self.client.generate_content.assert_called_once_with(
+            request, **expected_request_options
+        )
+
+    async def test_extra_headers_with_existing_request_optionss(self):
+        self.client.generate_content = unittest.mock.AsyncMock()
+        request = unittest.mock.ANY
+
+        extra_headers = {"Helicone-User-Id": "test-user-456"}
+        request_options = {
+            "timeout": 30,
+            "metadata": [("Existing-Header", "existing-value")]
+        }
+
+        model = generative_models.GenerativeModel(model_name="gemini-1.5-flash")
+
+        await model.generate_content_async("Hello", extra_headers=extra_headers, request_options=request_options)
+
+        expected_metadata = [("Existing-Header", "existing-value")] + list(extra_headers.items())
+        expected_request_options = {"timeout": 30, "metadata": expected_metadata}
+
+        self.client.generate_content.assert_called_once_with(
+            request, **expected_request_options
+        )
+
     async def test_streaming(self):
         # Generate text from text prompt
         model = generative_models.GenerativeModel(model_name="gemini-1.5-flash")


### PR DESCRIPTION
re:   #698 

## Description of the change
Modified the GenerativeModel.generate_content and GenerativeModel.generate_content_async method to accept an additional parameter extra_headers that would be passed to the underlying client method. This would allow users to set headers on a per-request basis while maintaining backward compatibility.

Added the required tests in test_generative_model.py and test_generative_model_async.py

## Type of change
Feature request


