### PR TITLE
feat: Add support for per-request metadata/headers in GenerativeModel.generate_content https://github.com/google-gemini/generative-ai-python/issues/698

### DIFF
--- a/google/generativeai/generative_models.py
+++ b/google/generativeai/generative_models.py
@@ -360,6 +360,7 @@ class GenerativeModel:
         tools: content_types.FunctionLibraryType | None = None,
         tool_config: content_types.ToolConfigType | None = None,
         request_options: helper_types.RequestOptionsType | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> generation_types.AsyncGenerateContentResponse:
         """The async version of `GenerativeModel.generate_content`."""
         if not contents:
@@ -381,6 +382,15 @@ class GenerativeModel:
 
         if request_options is None:
             request_options = {}
+
+        # Convert extra_headers to metadata format if provided
+        metadata = []
+        if extra_headers:
+            metadata = [(k, v) for k, v in extra_headers.items()]
+
+        # Add metadata to request_options
+        if metadata:
+            request_options["metadata"] = metadata
 
         try:
             if stream:

--- a/google/generativeai/generative_models.py
+++ b/google/generativeai/generative_models.py
@@ -244,6 +244,7 @@ class GenerativeModel:
         tools: content_types.FunctionLibraryType | None = None,
         tool_config: content_types.ToolConfigType | None = None,
         request_options: helper_types.RequestOptionsType | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> generation_types.GenerateContentResponse:
         """A multipurpose function to generate responses from the model.
 
@@ -318,6 +319,14 @@ class GenerativeModel:
 
         if request_options is None:
             request_options = {}
+
+        # Convert `extra_headers` to metadata format
+        if extra_headers:
+            metadata = [(k, v) for k, v in extra_headers.items()]
+            if "metadata" in request_options:
+                request_options["metadata"].extend(metadata)
+            else:
+                request_options["metadata"] = metadata
 
         try:
             if stream:

--- a/tests/test_generative_models.py
+++ b/tests/test_generative_models.py
@@ -48,10 +48,16 @@ class MockGenerativeServiceClient:
     def generate_content(
         self,
         request: protos.GenerateContentRequest,
+        *,
+        extra_headers: dict[str, str] | None = None,
         **kwargs,
     ) -> protos.GenerateContentResponse:
         self.test.assertIsInstance(request, protos.GenerateContentRequest)
         self.observed_requests.append(request)
+        # Convert extra_headers to metadata format and ensure it's in kwargs
+        if extra_headers:
+            metadata = [(k, v) for k, v in extra_headers.items()]
+            kwargs.setdefault("metadata", []).extend(metadata) 
         self.observed_kwargs.append(kwargs)
         response = self.responses["generate_content"].pop(0)
         return response
@@ -59,9 +65,15 @@ class MockGenerativeServiceClient:
     def stream_generate_content(
         self,
         request: protos.GetModelRequest,
+        *,
+        extra_headers: dict[str, str] | None = None,
         **kwargs,
     ) -> Iterable[protos.GenerateContentResponse]:
         self.observed_requests.append(request)
+        # Convert extra_headers to metadata format and ensure it's in kwargs
+        if extra_headers:
+            metadata = [(k, v) for k, v in extra_headers.items()]
+            kwargs.setdefault("metadata", []).extend(metadata)
         self.observed_kwargs.append(kwargs)
         response = self.responses["stream_generate_content"].pop(0)
         return response

--- a/tests/test_generative_models_async.py
+++ b/tests/test_generative_models_async.py
@@ -53,19 +53,35 @@ class AsyncTests(parameterized.TestCase, unittest.IsolatedAsyncioTestCase):
         @add_client_method
         async def generate_content(
             request: protos.GenerateContentRequest,
+            *,
+            extra_headers: dict[str, str] | None = None,
             **kwargs,
         ) -> protos.GenerateContentResponse:
             self.assertIsInstance(request, protos.GenerateContentRequest)
             self.observed_requests.append(request)
+
+            if extra_headers:
+                metadata = [(k, v) for k, v in extra_headers.items()]
+                kwargs.setdefault("metadata", []).extend(metadata)  # Merge with existing metadata if any
+
+            self.observed_kwargs.append(kwargs)
             response = self.responses["generate_content"].pop(0)
             return response
 
         @add_client_method
         async def stream_generate_content(
             request: protos.GetModelRequest,
+            *,
+            extra_headers: dict[str, str] | None = None,
             **kwargs,
         ) -> Iterable[protos.GenerateContentResponse]:
             self.observed_requests.append(request)
+            # Convert extra_headers to metadata format and ensure it's in kwargs
+            if extra_headers:
+                metadata = [(k, v) for k, v in extra_headers.items()]
+                kwargs.setdefault("metadata", []).extend(metadata)
+
+            self.observed_kwargs.append(kwargs)
             response = self.responses["stream_generate_content"].pop(0)
             return response
 


### PR DESCRIPTION
## Description of the change
Modified the GenerativeModel.generate_content and GenerativeModel.generate_content_async method to accept an additional parameter extra_headers that would be passed to the underlying client method. This would allow users to set headers on a per-request basis while maintaining backward compatibility.

Added the required tests in test_generative_model.py and test_generative_model_async.py


## Type of change
Feature request

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->
- [ ] I have performed a self-review of my code.
- [ ] I have added detailed comments to my code where applicable.
- [ ] I have verified that my change does not break existing code.
- [ ] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [ ] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [ ] I have read through the [Contributing Guide](https://github.com/google/generative-ai-python/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
