### PR TITLE
added consistency in embed model names

### DIFF
--- a/google/generativeai/embedding.py
+++ b/google/generativeai/embedding.py
@@ -28,7 +28,7 @@ from google.generativeai.types import model_types
 from google.generativeai.types import text_types
 from google.generativeai.types import content_types
 
-DEFAULT_EMB_MODEL = "models/embedding-001"
+DEFAULT_EMB_MODEL = "embedding-001"
 EMBEDDING_MAX_BATCH_SIZE = 100
 
 EmbeddingTaskType = protos.TaskType

--- a/samples/embed.py
+++ b/samples/embed.py
@@ -22,7 +22,7 @@ class UnitTests(absltest.TestCase):
 
         text = "Hello World!"
         result = genai.embed_content(
-            model="models/text-embedding-004", content=text, output_dimensionality=10
+            model="text-embedding-004", content=text, output_dimensionality=10
         )
         print(result["embedding"])
         # [END embed_content]
@@ -37,7 +37,7 @@ class UnitTests(absltest.TestCase):
             "How does the brain work?",
         ]
         result = genai.embed_content(
-            model="models/text-embedding-004", content=texts, output_dimensionality=10
+            model="text-embedding-004", content=texts, output_dimensionality=10
         )
         print(result)
         # [END batch_embed_contents]

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -26,7 +26,7 @@ from google.generativeai import client
 from absl.testing import absltest
 from absl.testing import parameterized
 
-DEFAULT_EMB_MODEL = "models/embedding-001"
+DEFAULT_EMB_MODEL = "embedding-001"
 
 
 class UnitTests(parameterized.TestCase):

--- a/tests/test_embedding_async.py
+++ b/tests/test_embedding_async.py
@@ -26,7 +26,7 @@ from google.generativeai import client as client_lib
 from absl.testing import absltest
 from absl.testing import parameterized
 
-DEFAULT_EMB_MODEL = "models/embedding-001"
+DEFAULT_EMB_MODEL = "embedding-001"
 
 
 class AsyncTests(parameterized.TestCase, unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
## Description of the change
added consistency for model names in `embed_content` function

Now, `genai.embed_content` function doesn't require a prefix of `models/`

Can be directly used as `genai.embed_content(
    model="embedding-001",
    content="What is the meaning of life?",
    task_type="retrieval_document",
    title="Embedding of single string")`

## Motivation
Fixed consistency issue#466

## Type of change
Feature request

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->
- [ ] I have performed a self-review of my code.
- [ ] I have added detailed comments to my code where applicable.
- [ ] I have verified that my change does not break existing code.
- [ ] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [ ] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [ ] I have read through the [Contributing Guide](https://github.com/google/generative-ai-python/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
