### PR TITLE
Add a GitHub Action to manage status: `awaiting user response`

### DIFF
--- a/.github/workflows/user-input.yml
+++ b/.github/workflows/user-input.yml
@@ -1,0 +1,14 @@
+name: Manage awaiting user response
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  remove_label:
+    runs-on: ubuntu-latest
+    if: "contains(github.event.issue.labels.*.name, 'status: awaiting user response')"
+    steps:
+      - uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: "status: awaiting user response"


### PR DESCRIPTION
A new comment on an issue with this label would get the label automatically removed.
